### PR TITLE
Parameter examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ This page will includes some examples on how to use this package.
 - [responses](https://github.com/BRIKEV/express-jsdoc-swagger/tree/master/examples/responses)
 - components - WIP
 - request body - WIP
-- parameters - WIP
+- [parameters](https://github.com/BRIKEV/express-jsdoc-swagger/tree/master/examples/parameters)
 - albumAPI - WIP
 
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,6 +5,9 @@
   "main": "index.js",
   "scripts": {
     "configuration:main": "node configuration/main.js",
+    "parameters:simple": "node parameters/simple.js",
+    "parameters:multiple": "node parameters/multiple.js",
+    "parameters:components": "node parameters/components.js",
     "responses:simple": "node responses/simple.js",
     "responses:multiple": "node responses/multiple.js",
     "responses:components": "node responses/components.js",

--- a/examples/parameters/components.js
+++ b/examples/parameters/components.js
@@ -1,0 +1,43 @@
+const express = require('express');
+
+const logger = require('../utils/logger');
+const expressJSDocSwagger = require('../..');
+
+const options = {
+  info: {
+    version: '1.0.0',
+    title: 'Albums store',
+    license: {
+      name: 'MIT',
+    },
+  },
+  file: './components.js',
+  baseDir: __dirname,
+};
+
+const app = express();
+const port = 3000;
+
+expressJSDocSwagger(app)(options);
+
+/**
+ * A song type
+ * @typedef {object} Song
+ * @property {string} title.required - The title
+ * @property {string} artist - The artist
+ * @property {number} year - The year - int64
+ */
+
+/**
+ * GET /api/v1/albums
+ * @summary This is the summary or description of the endpoint
+ * @param {array<Song>} name.query.required - name param description
+ * @return {array<Song>} 200 - success response - application/json
+ */
+app.get('/api/v1/albums', (req, res) => (
+  res.json([{
+    title: 'abum 1',
+  }])
+));
+
+app.listen(port, () => logger.info(`Example app listening at http://localhost:${port}`));

--- a/examples/parameters/multiple.js
+++ b/examples/parameters/multiple.js
@@ -1,0 +1,45 @@
+const express = require('express');
+
+const logger = require('../utils/logger');
+const expressJSDocSwagger = require('../..');
+
+const options = {
+  info: {
+    version: '1.0.0',
+    title: 'Albums store',
+    license: {
+      name: 'MIT',
+    },
+  },
+  file: './multiple.js',
+  baseDir: __dirname,
+};
+
+const app = express();
+const port = 3000;
+
+expressJSDocSwagger(app)(options);
+
+/**
+ * GET /api/v1
+ * @summary This is the summary or description of the endpoint
+ * @param {string} name.query.required - name param description
+ * @param {number} phone.param - phone number
+ * @return {string} 200 - success response
+ */
+app.get('/api/v1', (req, res) => res.send('Hello World!'));
+
+/**
+ * GET /api/v1/albums
+ * @summary This is the summary or description of the endpoint
+ * @param {array<string>} name.query.required.deprecated - name param description
+ * @param {number} phone.param
+ * @return {object} 200 - success response - application/json
+ */
+app.get('/api/v1/albums', (req, res) => (
+  res.json([{
+    title: 'abum 1',
+  }])
+));
+
+app.listen(port, () => logger.info(`Example app listening at http://localhost:${port}`));

--- a/examples/parameters/simple.js
+++ b/examples/parameters/simple.js
@@ -1,0 +1,43 @@
+const express = require('express');
+
+const logger = require('../utils/logger');
+const expressJSDocSwagger = require('../..');
+
+const options = {
+  info: {
+    version: '1.0.0',
+    title: 'Albums store',
+    license: {
+      name: 'MIT',
+    },
+  },
+  file: './simple.js',
+  baseDir: __dirname,
+};
+
+const app = express();
+const port = 3000;
+
+expressJSDocSwagger(app)(options);
+
+/**
+ * GET /api/v1
+ * @summary This is the summary or description of the endpoint
+ * @param {string} name.query.required - name param description
+ * @return {string} 200 - success response
+ */
+app.get('/api/v1', (req, res) => res.send('Hello World!'));
+
+/**
+ * GET /api/v1/albums
+ * @summary This is the summary or description of the endpoint
+ * @param {array<string>} name.query.required.deprecated - name param description
+ * @return {object} 200 - success response - application/json
+ */
+app.get('/api/v1/albums', (req, res) => (
+  res.json([{
+    title: 'abum 1',
+  }])
+));
+
+app.listen(port, () => logger.info(`Example app listening at http://localhost:${port}`));

--- a/transforms/paths/parameters.js
+++ b/transforms/paths/parameters.js
@@ -39,6 +39,7 @@ const parseParameter = param => {
     }),
     description: setProperty(options, 'description', {
       type: 'string',
+      defaultValue: '',
     }),
     required: setProperty(options, 'required', {
       type: 'boolean',

--- a/transforms/utils/setProperty.js
+++ b/transforms/utils/setProperty.js
@@ -13,7 +13,7 @@ const setProperty = entity => {
     }
     const value = item[key];
     if (options.required && value === undefined) throw requiredError(key, item);
-    if (value === undefined) return options.defaultValue;
+    if (value === undefined || value === null) return options.defaultValue;
     // eslint-disable-next-line
     if (typeof (value) !== options.type) warnType(options.type, value);
     return value;


### PR DESCRIPTION
This PR includes:

- Parameter feature examples.
- Fix a problem when description is empty.

The second point is not an error as everything works well but when we don't set the description the value is null and as the type should be string it shows a warning.
Even if I add the `defaultValue: '',` the warning appears. What I did was add null as well as undefined to return the default value.

This change won't affect coverage.
