### PR TITLE
fix: only comment regex

### DIFF
--- a/consumers/utils/getComments.js
+++ b/consumers/utils/getComments.js
@@ -1,5 +1,5 @@
 
-const COMMENTS_PATTERN = /(^(\/\*+[\s\S]*?\*\/)|(\/\*+.*\*\/)|^\/\/.*?[\r\n])[\r\n]*/gm;
+const COMMENTS_PATTERN = /((\/\*+[\s\S]*?\*\/)|(\/\*+.*\*\/)|^\/\/.*?[\r\n])[\r\n]*/gm;
 const BREAK_LINE = /\n/g;
 
 const getComments = text => {

--- a/test/consumers/getOnlyComments/index.test.js
+++ b/test/consumers/getOnlyComments/index.test.js
@@ -100,4 +100,24 @@ describe('get only comments consumer method', () => {
     expect(result).toHaveLength(3);
     expect(result).toEqual(expected);
   });
+
+  it('should return JSdoc comment that is not at the begining of the line', () => {
+    const input = [`
+      File with comments with tabulation
+    
+      /**
+       * @param  {[type]}
+       * @param  {[type]}
+       * @return {[type]}
+       */
+    `];
+    const expected = [`/**
+       * @param  {[type]}
+       * @param  {[type]}
+       * @return {[type]}
+       */`];
+    const result = getOnlyComments(input);
+    expect(result).toHaveLength(1);
+    expect(result).toEqual(expected);
+  });
 });


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:

This PR fixes a problem when there is code before the comment and the comment has spaces or tabs.

