### PR TITLE
Including empty object causes errors in doc validation

### DIFF
--- a/transforms/basic/info.js
+++ b/transforms/basic/info.js
@@ -11,8 +11,8 @@ const getInfo = (options = {}) => ({
     type: 'string',
     defaultValue: 'Add your description',
   }),
-  contact: options.contact ? getContact(options.contact) : {},
-  license: options.license ? license(options.license) : {},
+  contact: options.contact ? getContact(options.contact) : undefined,
+  license: options.license ? license(options.license) : undefined,
   termsOfService: setProperty(options, 'termsOfService', {
     type: 'string',
     defaultValue: '',

--- a/transforms/basic/servers.js
+++ b/transforms/basic/servers.js
@@ -9,7 +9,7 @@ const setServer = (server = {}) => ({
     type: 'string',
     defaultValue: '',
   }),
-  variables: server.variables ? server.variables : {},
+  variables: server.variables ? server.variables : undefined,
 });
 
 const setServers = (servers = []) => {


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:

Hey, thanks for developping this library, it's great !

I use only the processSwagger() part so I can generate and host the file separately. This makes debugging the swagger.json file easier for me.

I noticed that when I don't add contact and license to my options object, the library stills adds them with a default value of empty object which causes an error in swaggger's validator :

`Structural error at info.license
should have required property 'name'
missingProperty: name`

The fix in this PR replaces the default {} value with undefined to fix this error. I didn't run any tests but it doesn't look like it breaks anything.

Thank you !