### PR TITLE
Allow combining schemas on typedef 

### DIFF
--- a/test/transforms/components/index.test.js
+++ b/test/transforms/components/index.test.js
@@ -645,4 +645,83 @@ describe('parseComponents method', () => {
     const result = parseComponents({}, parsedJSDocs);
     expect(result).toEqual(expected);
   });
+
+  it('Should parse a SingleAlbum schema with allOf reference of Song.', () => {
+    const jsodInput = [`
+      /**
+       * SingleAlbum
+       * @typedef {allOf|Song} SingleAlbum
+       * @property {array<Song>} Songs
+       */
+    `];
+    const expected = {
+      components: {
+        schemas: {
+          SingleAlbum: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/Song',
+              },
+            ],
+            type: 'object',
+            required: [],
+            description: 'SingleAlbum',
+            properties: {
+              Songs: {
+                type: 'array',
+                description: '',
+                items: {
+                  $ref: '#/components/schemas/Song',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = parseComponents({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
+
+  it('Should parse a SongOrAlbum schema with oneOf reference of Song and Album.', () => {
+    const jsodInput = [`
+      /**
+       * SongOrAlbum
+       * @typedef {oneOf|Song|Album} SongOrAlbum
+       * @property {array<Song>} Songs
+       */
+    `];
+    const expected = {
+      components: {
+        schemas: {
+          SongOrAlbum: {
+            oneOf: [
+              {
+                $ref: '#/components/schemas/Song',
+              },
+              {
+                $ref: '#/components/schemas/Album',
+              },
+            ],
+            type: 'object',
+            required: [],
+            description: 'SongOrAlbum',
+            properties: {
+              Songs: {
+                type: 'array',
+                description: '',
+                items: {
+                  $ref: '#/components/schemas/Song',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = parseComponents({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
 });

--- a/transforms/components/index.js
+++ b/transforms/components/index.js
@@ -60,8 +60,12 @@ const parseSchema = schema => {
   const typedef = getTagInfo(schema.tags, 'typedef');
   const propertyValues = getTagsInfo(schema.tags, 'property');
   if (!typedef || !typedef.name) return {};
+  const {
+    elements,
+  } = typedef.type;
   return {
     [typedef.name]: {
+      ...combineSchema(elements),
       description: schema.description,
       required: isPropertyRequired(propertyValues),
       type: 'object',


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [x] Feature
 - [x] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:
For parameters and return types we can combine schemas with `allOf`, `oneOf`, `anyOf`.

I thought we should be able to use them for schema definition (`@typedef`)