### PR TITLE
feat: add support for `example` annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,29 @@ app.get('/api/v1/album', (req, res) => (
 ));
 ```
 
+5. Basic endpoint definition with code example for response body
+```javascript
+/**
+ * GET /api/v1/albums
+ * @summary This is the summary or description of the endpoint
+ * @tags album
+ * @return {array<Song>} 200 - success response - application/json
+ * @example response - 200 - success response example
+ * [
+ *   {
+ *     "title": "Bury the light",
+ *     "artist": "Casey Edwards ft. Victor Borba",
+ *     "year": 2020
+ *   }
+ * ]
+ */
+app.get('/api/v1/albums', (req, res) => (
+  res.json([{
+    title: 'track 1',
+  }])
+));
+```
+
 You can find more examples [here](https://github.com/BRIKEV/express-jsdoc-swagger/tree/master/examples), or visit our [documentation](https://brikev.github.io/express-jsdoc-swagger-docs/#/).
 
 ## Contributors ✨

--- a/examples/package.json
+++ b/examples/package.json
@@ -19,7 +19,7 @@
     "requestBody:components": "node requestBody/components.js",
     "requestBody:formdata": "node requestBody/formdata.js",
     "requestBody:formUrlencoded": "node requestBody/formUrlencoded.js",
-    "requestBody:withExample": "node requestBody/withExample.js",
+    "requestBody:withExamples": "node requestBody/withExamples.js",
     "security:basic-auth": "node security/basic-auth.js",
     "components:simple": "node components/simple.js",
     "components:enum": "node components/enum.js",

--- a/examples/package.json
+++ b/examples/package.json
@@ -18,6 +18,7 @@
     "requestBody:components": "node requestBody/components.js",
     "requestBody:formdata": "node requestBody/formdata.js",
     "requestBody:formUrlencoded": "node requestBody/formUrlencoded.js",
+    "requestBody:withExample": "node requestBody/withExample.js",
     "security:basic-auth": "node security/basic-auth.js",
     "components:simple": "node components/simple.js",
     "components:enum": "node components/enum.js",

--- a/examples/package.json
+++ b/examples/package.json
@@ -13,6 +13,7 @@
     "responses:multiple": "node responses/multiple.js",
     "responses:components": "node responses/components.js",
     "responses:full-example": "node responses/full-example.js",
+    "responses:withExamples": "node responses/withExamples.js",
     "requestBody:simple": "node requestBody/simple.js",
     "requestBody:multiple": "node requestBody/multiple.js",
     "requestBody:components": "node requestBody/components.js",

--- a/examples/requestBody/withExample.js
+++ b/examples/requestBody/withExample.js
@@ -1,0 +1,54 @@
+const express = require('express');
+
+const logger = require('../utils/logger');
+const expressJSDocSwagger = require('../..');
+
+const options = {
+  info: {
+    version: '1.0.0',
+    title: 'Albums store',
+    license: {
+      name: 'MIT',
+    },
+  },
+  filesPattern: './withExample.js',
+  baseDir: __dirname,
+};
+
+const app = express();
+const port = 3000;
+
+expressJSDocSwagger(app)(options);
+
+/**
+ * A song
+ * @typedef {object} Song
+ * @property {string} title.required - The title
+ * @property {string} artist - The artist
+ * @property {integer} year - The year - int64
+ */
+
+/**
+ * POST /api/v1/song
+ * @param {Song} request.body.required - song info
+ * @return {object} 200 - song response
+ * @return {object} 400 - Bad request response
+ * @example request - example payload
+ * {
+ *   "title": "untitled song",
+ *   "artist": "anonymous",
+ *   "year": 2019
+ * }
+ * @example response - 200 - example success response
+ * {
+ *   "message": "you have saved song"
+ * }
+ * @example response - 400 - example error response
+ * {
+ *   "message": "failed to save song",
+ *   "errCode": "E120"
+ * }
+ */
+app.post('/api/v1/songs', (req, res) => res.send('You save a song!'));
+
+app.listen(port, () => logger.info(`Example app listening at http://localhost:${port}`));

--- a/examples/requestBody/withExamples.js
+++ b/examples/requestBody/withExamples.js
@@ -11,7 +11,7 @@ const options = {
       name: 'MIT',
     },
   },
-  filesPattern: './withExample.js',
+  filesPattern: './withExamples.js',
   baseDir: __dirname,
 };
 
@@ -33,22 +33,21 @@ expressJSDocSwagger(app)(options);
  * @param {Song} request.body.required - song info
  * @return {object} 200 - song response
  * @return {object} 400 - Bad request response
- * @example request - example payload
+ * @example request - payload example
  * {
- *   "title": "untitled song",
- *   "artist": "anonymous",
- *   "year": 2019
+ *   "title": "Bury The Light",
+ *   "artist": "Casey Edwards ft. Victor Borba",
+ *   "year": 2020
  * }
- * @example response - 200 - example success response
+ * @example request - other payload example
  * {
- *   "message": "you have saved song"
- * }
- * @example response - 400 - example error response
- * {
- *   "message": "failed to save song",
- *   "errCode": "E120"
+ *   "title": "The war we made",
+ *   "artist": "Red",
+ *   "year": 2020
  * }
  */
-app.post('/api/v1/songs', (req, res) => res.send('You save a song!'));
+app.post('/api/v1/song', (req, res) => res.send({
+  message: 'You added a song!',
+}));
 
 app.listen(port, () => logger.info(`Example app listening at http://localhost:${port}`));

--- a/examples/responses/withExamples.js
+++ b/examples/responses/withExamples.js
@@ -1,0 +1,68 @@
+const express = require('express');
+
+const logger = require('../utils/logger');
+const expressJSDocSwagger = require('../..');
+
+const options = {
+  info: {
+    version: '1.0.0',
+    title: 'Pet store',
+    license: {
+      name: 'MIT',
+    },
+  },
+  filesPattern: './withExamples.js',
+  baseDir: __dirname,
+};
+
+const app = express();
+const port = 3000;
+
+expressJSDocSwagger(app)(options);
+
+/**
+ * A pet
+ * @typedef {object} Pet
+ * @property {string} name.required - The name
+ * @property {string} type.required - The type of pet
+ * @property {string} breed - The breed
+ */
+
+/**
+ * GET /api/v1/pet
+ * @return {Pet[]} 200 - success response
+ * @return {object} 403 - Bad request response
+ * @example response - 200 - example success response
+ * [
+ *   {
+ *     "name": "Blaze",
+ *     "type": "Dog"
+ *     "breed": "Siberian husky"
+ *   },
+ *   {
+ *     "name": "Luna",
+ *     "type": "Cat"
+ *   }
+ * ]
+ * @example response - 200 - second example success response
+ * [
+ *   {
+ *     "name": "Hachiko",
+ *     "type": "Dog"
+ *     "breed": "Akita Inu"
+ *   },
+ * ]
+ * @example response - 403 - example error response
+ * {
+ *   "message": "you cannot access pet data",
+ * }
+ */
+app.get('/api/v1/pet', (req, res) => (
+  res.json([{
+    name: 'Hachiko',
+    type: 'Dog',
+    breed: 'Akita Inu'
+  }])
+));
+
+app.listen(port, () => logger.info(`Example app listening at http://localhost:${port}`));

--- a/examples/responses/withExamples.js
+++ b/examples/responses/withExamples.js
@@ -31,7 +31,7 @@ expressJSDocSwagger(app)(options);
 /**
  * GET /api/v1/pet
  * @return {Pet[]} 200 - success response
- * @return {object} 403 - Bad request response
+ * @return {object} 403 - forbidden request response
  * @example response - 200 - example success response
  * [
  *   {

--- a/test/transforms/paths/requestBody.test.js
+++ b/test/transforms/paths/requestBody.test.js
@@ -314,4 +314,49 @@ describe('request body tests', () => {
     const result = setPaths({}, parsedJSDocs);
     expect(result).toEqual(expected);
   });
+
+  it('should parse jsdoc request body with examples', () => {
+    const jsdocInput = [`
+      /**
+       * POST /api/v1
+       * @param {string} request.body.required - name body description
+       * @example request - example payload
+       * sample input string
+       */
+    `];
+    const expected = {
+      paths: {
+        '/api/v1': {
+          post: {
+            deprecated: false,
+            summary: '',
+            responses: {},
+            tags: [],
+            security: [],
+            parameters: [],
+            requestBody: {
+              description: 'name body description',
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'string',
+                  },
+                  examples: {
+                    example1: {
+                      summary: 'example payload',
+                      value: 'sample input string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsdocInput);
+    const result = setPaths({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
 });

--- a/test/transforms/paths/responses.test.js
+++ b/test/transforms/paths/responses.test.js
@@ -296,4 +296,74 @@ describe('response tests', () => {
     const result = setPaths({}, parsedJSDocs);
     expect(result).toEqual(expected);
   });
+
+  it('should parse jsdoc path response with examples', () => {
+    const jsdocInput = [`
+      /**
+       * GET /api/v1
+       * @summary This is the summary or description of the endpoint
+       * @return {Song} 200 - success response - application/json
+       * @return {object} 403 - forbidden response - application/json
+       * @example response - 200 - example success response
+       * {
+       *   "title": "untitled song",
+       *   "artist": "anonymous"
+       * }
+       * @example response - 403 - example error response
+       * {
+       *   "error": "failed to retrieve results"
+       * }
+       */
+    `];
+    const expected = {
+      paths: {
+        '/api/v1': {
+          get: {
+            deprecated: false,
+            summary: 'This is the summary or description of the endpoint',
+            parameters: [],
+            tags: [],
+            security: [],
+            responses: {
+              200: {
+                description: 'success response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/Song',
+                    },
+                    examples: {
+                      example1: {
+                        summary: 'example success response',
+                        value: '{\n  "title": "untitled song",\n  "artist": "anonymous"\n}',
+                      },
+                    },
+                  },
+                },
+              },
+              403: {
+                description: 'forbidden response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                    },
+                    examples: {
+                      example2: {
+                        summary: 'example error response',
+                        value: '{\n  "error": "failed to retrieve results"\n}',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsdocInput);
+    const result = setPaths({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
 });

--- a/transforms/paths/content.js
+++ b/transforms/paths/content.js
@@ -2,11 +2,12 @@ const getSchema = require('./schema');
 
 const DEFAULT_CONTENT_TYPE = 'application/json';
 
-const getContent = entity => (type, contentType, originalValue) => {
+const getContent = entity => (type, contentType, originalValue, examples) => {
   const schema = getSchema(entity, originalValue)(type);
   return {
     [contentType || DEFAULT_CONTENT_TYPE]: {
       schema,
+      examples,
     },
   };
 };

--- a/transforms/paths/examples.js
+++ b/transforms/paths/examples.js
@@ -23,9 +23,9 @@ const parseResponsePayloadExample = (description, value) => {
 };
 
 const parseExample = example => {
-  const bodyStartIndex = example.description.indexOf('\r\n');
+  const bodyStartIndex = example.description.replace(/\r\n/gi, '\n').indexOf('\n');
   const description = example.description.substring(0, bodyStartIndex);
-  const content = example.description.substring(bodyStartIndex);
+  const content = example.description.substring(bodyStartIndex + 1);
 
   const [type, ...metadata] = mapDescription(description);
 

--- a/transforms/paths/examples.js
+++ b/transforms/paths/examples.js
@@ -1,3 +1,6 @@
+const STATUS_CODES = require('./validStatusCodes');
+
+const errorMessage = require('../utils/errorMessage');
 const mapDescription = require('../utils/mapDescription');
 
 const REQUEST_BODY = 'request';
@@ -14,6 +17,10 @@ const parseRequestPayloadExample = (description, value) => {
 
 const parseResponsePayloadExample = (description, value) => {
   const [status, summary] = description;
+  if (!STATUS_CODES[status]) {
+    errorMessage(`${status} is not a valid status for a response`);
+    return {};
+  }
   return {
     type: RESPONSE_BODY,
     status,
@@ -24,9 +31,10 @@ const parseResponsePayloadExample = (description, value) => {
 
 const parseExample = example => {
   const tagDescription = example.description.replace(/\r\n/gi, '\n');
-  const bodyStartIndex = tagDescription.indexOf('\n');
-  const description = tagDescription.substring(0, bodyStartIndex);
-  const content = tagDescription.substring(bodyStartIndex + 1);
+  const contentStartIndex = tagDescription.indexOf('\n');
+
+  const content = tagDescription.substring(contentStartIndex + 1);
+  const description = tagDescription.substring(0, contentStartIndex);
 
   const [type, ...metadata] = mapDescription(description);
 
@@ -36,10 +44,33 @@ const parseExample = example => {
     case RESPONSE_BODY:
       return parseResponsePayloadExample(metadata, content);
     default:
+      errorMessage(`Cannot determine where to use example of type ${type}`);
       return {};
   }
 };
 
+/**
+ *  This receives a set of values extracted from "example" tags, and translates
+ * them to objects with the example type (request or response), summary, status
+ * code (only applicable to response types) and the example code itself.
+ *
+ * @param {object[]} exampleValues - Set of example tags, which description are
+ *  expected to have the following information in order to be parsed properly:
+ *
+ *    > For request body examples:
+ *
+ *      response - [example summary]
+ *      [example content]
+ *
+ *    > For response examples:
+ *
+ *      response - [http status code] - [example summary]
+ *      [example content]
+ *
+ * @return {object[]} List of objects containing the example type (request or
+ *  response), summary, status code (only applicable to response types) and
+ *  the example code itself.
+ */
 const examplesGenerator = (exampleValues = []) => {
   if (!exampleValues || !Array.isArray(exampleValues)) return [];
   const examples = exampleValues.map(parseExample).filter(example => example.type);

--- a/transforms/paths/examples.js
+++ b/transforms/paths/examples.js
@@ -23,9 +23,10 @@ const parseResponsePayloadExample = (description, value) => {
 };
 
 const parseExample = example => {
-  const bodyStartIndex = example.description.replace(/\r\n/gi, '\n').indexOf('\n');
-  const description = example.description.substring(0, bodyStartIndex);
-  const content = example.description.substring(bodyStartIndex + 1);
+  const tagDescription = example.description.replace(/\r\n/gi, '\n');
+  const bodyStartIndex = tagDescription.indexOf('\n');
+  const description = tagDescription.substring(0, bodyStartIndex);
+  const content = tagDescription.substring(bodyStartIndex + 1);
 
   const [type, ...metadata] = mapDescription(description);
 

--- a/transforms/paths/examples.js
+++ b/transforms/paths/examples.js
@@ -1,0 +1,42 @@
+const mapDescription = require('../utils/mapDescription');
+
+const REQUEST_BODY = 'request';
+const RESPONSE_BODY = 'response';
+
+const parseExample = example => {
+  const bodyStartIndex = example.description.indexOf('\r\n');
+  const description = example.description.substring(0, bodyStartIndex);
+  const sampleBody = example.description.substring(bodyStartIndex + 1);
+
+  const [type, ...data] = mapDescription(description);
+
+  if (type === REQUEST_BODY) {
+    const [summary] = data;
+    return {
+      type,
+      summary,
+      value: sampleBody,
+    };
+  }
+
+  if (type === RESPONSE_BODY) {
+    const [status, summary] = data;
+    return {
+      type,
+      status,
+      summary,
+      value: sampleBody,
+    };
+  }
+
+  return {};
+};
+
+const examplesGenerator = (exampleValues = []) => {
+  if (!exampleValues || !Array.isArray(exampleValues)) return [];
+  // TODO: filter invalid examples
+  const examples = exampleValues.map(parseExample).filter(example => example.type);
+  return examples;
+};
+
+module.exports = examplesGenerator;

--- a/transforms/paths/examples.js
+++ b/transforms/paths/examples.js
@@ -3,38 +3,44 @@ const mapDescription = require('../utils/mapDescription');
 const REQUEST_BODY = 'request';
 const RESPONSE_BODY = 'response';
 
+const parseRequestPayloadExample = (description, value) => {
+  const [summary] = description;
+  return {
+    type: REQUEST_BODY,
+    summary,
+    value,
+  };
+};
+
+const parseResponsePayloadExample = (description, value) => {
+  const [status, summary] = description;
+  return {
+    type: RESPONSE_BODY,
+    status,
+    summary,
+    value,
+  };
+};
+
 const parseExample = example => {
   const bodyStartIndex = example.description.indexOf('\r\n');
   const description = example.description.substring(0, bodyStartIndex);
-  const sampleBody = example.description.substring(bodyStartIndex + 1);
+  const content = example.description.substring(bodyStartIndex);
 
-  const [type, ...data] = mapDescription(description);
+  const [type, ...metadata] = mapDescription(description);
 
-  if (type === REQUEST_BODY) {
-    const [summary] = data;
-    return {
-      type,
-      summary,
-      value: sampleBody,
-    };
+  switch (type) {
+    case REQUEST_BODY:
+      return parseRequestPayloadExample(metadata, content);
+    case RESPONSE_BODY:
+      return parseResponsePayloadExample(metadata, content);
+    default:
+      return {};
   }
-
-  if (type === RESPONSE_BODY) {
-    const [status, summary] = data;
-    return {
-      type,
-      status,
-      summary,
-      value: sampleBody,
-    };
-  }
-
-  return {};
 };
 
 const examplesGenerator = (exampleValues = []) => {
   if (!exampleValues || !Array.isArray(exampleValues)) return [];
-  // TODO: filter invalid examples
   const examples = exampleValues.map(parseExample).filter(example => example.type);
   return examples;
 };

--- a/transforms/paths/examples.js
+++ b/transforms/paths/examples.js
@@ -6,16 +6,18 @@ const mapDescription = require('../utils/mapDescription');
 const REQUEST_BODY = 'request';
 const RESPONSE_BODY = 'response';
 
-const parseRequestPayloadExample = (description, value) => {
+// Generates a new object with information on a request body example
+const parseRequestPayloadExample = (description, content) => {
   const [summary] = description;
   return {
     type: REQUEST_BODY,
     summary,
-    value,
+    value: content,
   };
 };
 
-const parseResponsePayloadExample = (description, value) => {
+// Generates a new object with information on a response body example
+const parseResponsePayloadExample = (description, content) => {
   const [status, summary] = description;
   if (!STATUS_CODES[status]) {
     errorMessage(`${status} is not a valid status for a response`);
@@ -25,16 +27,30 @@ const parseResponsePayloadExample = (description, value) => {
     type: RESPONSE_BODY,
     status,
     summary,
-    value,
+    value: content,
   };
 };
 
-const parseExample = example => {
-  const tagDescription = example.description.replace(/\r\n/gi, '\n');
-  const contentStartIndex = tagDescription.indexOf('\n');
+/**
+ *  Parses a single example tag contents. Depending on the type (response or
+ * request), the expected data and returned structure will be different.
+ *
+ *  To prevent compatibility issues between SO, all `\r\n` instances (used in
+ * Windows by default as end of line sequence) will be replaced by `\n`.
+ *
+ * @param {string} exampleTagDescription - Text passed to the example tag.
+ *
+ * @return {object} Structured information about the example, including the
+ * example type (request or response), summary, status code (only applicable to
+ * response types) and the example code itself.
+ */
+const parseExample = ({ description: exampleTagDescription }) => {
+  const formattedTagDescription = exampleTagDescription.replace(/\r\n/gi, '\n');
 
-  const content = tagDescription.substring(contentStartIndex + 1);
-  const description = tagDescription.substring(0, contentStartIndex);
+  // The example content starts right after the first end of line character
+  const contentStartIndex = formattedTagDescription.indexOf('\n');
+  const content = formattedTagDescription.substring(contentStartIndex + 1);
+  const description = formattedTagDescription.substring(0, contentStartIndex);
 
   const [type, ...metadata] = mapDescription(description);
 
@@ -54,7 +70,7 @@ const parseExample = example => {
  * them to objects with the example type (request or response), summary, status
  * code (only applicable to response types) and the example code itself.
  *
- * @param {object[]} exampleValues - Set of example tags, which description are
+ * @param {object[]} exampleTags - Set of example tags, which description are
  *  expected to have the following information in order to be parsed properly:
  *
  *    > For request body examples:
@@ -71,9 +87,9 @@ const parseExample = example => {
  *  response), summary, status code (only applicable to response types) and
  *  the example code itself.
  */
-const examplesGenerator = (exampleValues = []) => {
-  if (!exampleValues || !Array.isArray(exampleValues)) return [];
-  const examples = exampleValues.map(parseExample).filter(example => example.type);
+const examplesGenerator = (exampleTags = []) => {
+  if (!exampleTags || !Array.isArray(exampleTags)) return [];
+  const examples = exampleTags.map(parseExample).filter(example => example.type);
   return examples;
 };
 

--- a/transforms/paths/index.js
+++ b/transforms/paths/index.js
@@ -1,3 +1,4 @@
+const examplesGenerator = require('./examples');
 const responsesGenerator = require('./responses');
 const parametersGenerator = require('./parameters');
 const requestBodyGenerator = require('./requestBody');
@@ -27,12 +28,20 @@ const setRequestBody = (lowerCaseMethod, bodyValues) => {
 const bodyParams = ({ name }) => name.includes('request.body');
 
 const pathValues = tags => {
+  // TODO: parse examples
+  const examplesValues = getTagsInfo(tags, 'example');
+  // TODO: pass param to filter type of values to parse (request , response)
+  const examples = examplesGenerator(examplesValues);
+
   const summary = getTagInfo(tags, 'summary');
   const deprecated = getTagInfo(tags, 'deprecated');
   const isDeprecated = !!deprecated;
   /* Response info */
   const returnValues = getTagsInfo(tags, 'return');
-  const responses = responsesGenerator(returnValues);
+  //console.log(returnValues);
+  // TODO: append examples to response
+  const responseExamples = examples.filter(example => example.type === 'response');
+  const responses = responsesGenerator(returnValues, responseExamples);
   /* Parameters info */
   const paramValues = getTagsInfo(tags, 'param');
   const parameters = parametersGenerator(paramValues);
@@ -41,6 +50,7 @@ const pathValues = tags => {
   /* Security info */
   const securityValues = getTagsInfo(tags, 'security');
   /* Request body info */
+  // TODO: append examples to request body
   const bodyValues = paramValues.filter(bodyParams);
   return {
     summary,
@@ -54,6 +64,7 @@ const pathValues = tags => {
 };
 
 const parsePath = (path, state) => {
+  //console.log('parsePath', path);
   if (!path.description || !path.tags) return {};
   const [method, endpoint] = path.description.split(' ');
   // if jsdoc comment does not contain structure <Method> - <Endpoint> is not valid path

--- a/transforms/paths/index.js
+++ b/transforms/paths/index.js
@@ -28,9 +28,7 @@ const setRequestBody = (lowerCaseMethod, bodyValues, requestExamples) => {
 const bodyParams = ({ name }) => name.includes('request.body');
 
 const pathValues = tags => {
-  // TODO: parse examples
   const examplesValues = getTagsInfo(tags, 'example');
-  // TODO: pass param to filter type of values to parse (request , response)
   const examples = examplesGenerator(examplesValues);
 
   const summary = getTagInfo(tags, 'summary');
@@ -48,7 +46,6 @@ const pathValues = tags => {
   /* Security info */
   const securityValues = getTagsInfo(tags, 'security');
   /* Request body info */
-  // TODO: append examples to request body
   const bodyValues = paramValues.filter(bodyParams);
   return {
     summary,
@@ -63,7 +60,6 @@ const pathValues = tags => {
 };
 
 const parsePath = (path, state) => {
-  //console.log('parsePath', path);
   if (!path.description || !path.tags) return {};
   const [method, endpoint] = path.description.split(' ');
   // if jsdoc comment does not contain structure <Method> - <Endpoint> is not valid path

--- a/transforms/paths/index.js
+++ b/transforms/paths/index.js
@@ -19,9 +19,9 @@ const formatSecurity = (securityValues = []) => securityValues.map(({ descriptio
 
 const formatSummary = summary => (summary || {}).description || '';
 
-const setRequestBody = (lowerCaseMethod, bodyValues) => {
+const setRequestBody = (lowerCaseMethod, bodyValues, requestExamples) => {
   const hasBodyValues = bodyValues.length > 0;
-  const requestBody = requestBodyGenerator(bodyValues);
+  const requestBody = requestBodyGenerator(bodyValues, requestExamples);
   return bodyMethods[lowerCaseMethod] && hasBodyValues ? { requestBody } : {};
 };
 
@@ -38,8 +38,6 @@ const pathValues = tags => {
   const isDeprecated = !!deprecated;
   /* Response info */
   const returnValues = getTagsInfo(tags, 'return');
-  //console.log(returnValues);
-  // TODO: append examples to response
   const responseExamples = examples.filter(example => example.type === 'response');
   const responses = responsesGenerator(returnValues, responseExamples);
   /* Parameters info */
@@ -60,6 +58,7 @@ const pathValues = tags => {
     tagsValues,
     bodyValues,
     securityValues,
+    examples,
   };
 };
 
@@ -72,8 +71,9 @@ const parsePath = (path, state) => {
   if (!validHTTPMethod(lowerCaseMethod)) return {};
   const { tags } = path;
   const {
-    summary, bodyValues, isDeprecated, responses, parameters, tagsValues, securityValues,
+    summary, bodyValues, isDeprecated, responses, parameters, tagsValues, securityValues, examples,
   } = pathValues(tags);
+  const requestExamples = examples.filter(example => example.type === 'request');
   return {
     ...state,
     [endpoint]: {
@@ -85,7 +85,7 @@ const parsePath = (path, state) => {
         responses,
         parameters,
         tags: formatTags(tagsValues),
-        ...(setRequestBody(lowerCaseMethod, bodyValues)),
+        ...(setRequestBody(lowerCaseMethod, bodyValues, requestExamples)),
       },
     },
   };

--- a/transforms/paths/requestBody.js
+++ b/transforms/paths/requestBody.js
@@ -5,7 +5,17 @@ const mapDescription = require('../utils/mapDescription');
 const REQUIRED = 'required';
 const BODY_PARAM = 'body';
 
-const parseBodyParameter = (currentState, body) => {
+const formatExamples = (exampleValues = []) => {
+  return exampleValues.reduce((exampleMap, example, i) => ({
+    ...exampleMap,
+    [`example${i + 1}`]: {
+      summary: example.summary,
+      value: example.value,
+    },
+  }), {});
+};
+
+const parseBodyParameter = (currentState, body, examples) => {
   const [name, inOption, ...extraOptions] = body.name.split('.');
   if (inOption !== BODY_PARAM) {
     return {};
@@ -17,6 +27,9 @@ const parseBodyParameter = (currentState, body) => {
     required: isRequired,
     description,
   };
+
+  const requestExamples = formatExamples(examples);
+
   return {
     ...currentState,
     description: setProperty(options, 'description', {
@@ -28,17 +41,17 @@ const parseBodyParameter = (currentState, body) => {
     }),
     content: {
       ...currentState.content,
-      ...getContent(body.type, contentType, body.description),
+      ...getContent(body.type, contentType, body.description, requestExamples),
     },
   };
 };
 
 const INITIAL_STATE = { content: {} };
 
-const requestBodyGenerator = (params = []) => {
+const requestBodyGenerator = (params = [], examples) => {
   if (!params || !Array.isArray(params)) return {};
   const requestBody = params.reduce((acc, body) => (
-    { ...acc, ...parseBodyParameter(acc, body) }
+    { ...acc, ...parseBodyParameter(acc, body, examples) }
   ), INITIAL_STATE);
   return requestBody;
 };

--- a/transforms/paths/requestBody.js
+++ b/transforms/paths/requestBody.js
@@ -5,15 +5,14 @@ const mapDescription = require('../utils/mapDescription');
 const REQUIRED = 'required';
 const BODY_PARAM = 'body';
 
-const formatExamples = (exampleValues = []) => {
-  return exampleValues.reduce((exampleMap, example, i) => ({
+const formatExamples = (exampleValues = []) => exampleValues
+  .reduce((exampleMap, example, i) => ({
     ...exampleMap,
     [`example${i + 1}`]: {
       summary: example.summary,
       value: example.value,
     },
   }), {});
-};
 
 const parseBodyParameter = (currentState, body, examples) => {
   const [name, inOption, ...extraOptions] = body.name.split('.');

--- a/transforms/paths/requestBody.js
+++ b/transforms/paths/requestBody.js
@@ -27,7 +27,10 @@ const parseBodyParameter = (currentState, body, examples) => {
     description,
   };
 
-  const requestExamples = formatExamples(examples);
+  let requestExamples;
+  if (Array.isArray(examples) && examples.length > 0) {
+    requestExamples = formatExamples(examples);
+  }
 
   return {
     ...currentState,

--- a/transforms/paths/responses.js
+++ b/transforms/paths/responses.js
@@ -23,8 +23,8 @@ const formatResponses = (values, examples) => values.reduce((acc, value) => {
   };
 }, {});
 
-const formatExamples = (exampleValues = []) => {
-  return exampleValues.reduce((exampleMap, example, i) => ({
+const formatExamples = (exampleValues = []) => exampleValues
+  .reduce((exampleMap, example, i) => ({
     ...exampleMap,
     [example.status]: {
       ...exampleMap[example.status],
@@ -34,7 +34,6 @@ const formatExamples = (exampleValues = []) => {
       },
     },
   }), {});
-};
 
 const responsesGenerator = (returnValues = [], exampleValues = []) => {
   if (!returnValues || !Array.isArray(returnValues)) return {};

--- a/transforms/paths/responses.js
+++ b/transforms/paths/responses.js
@@ -5,7 +5,7 @@ const getContent = require('./content')('@return');
 
 const hasOldContent = (value, status) => (value[status] && value[status].content);
 
-const formatResponses = values => values.reduce((acc, value) => {
+const formatResponses = (values, examples) => values.reduce((acc, value) => {
   const [status, description, contentType] = mapDescription(value.description);
   if (!STATUS_CODES[status]) {
     errorMessage(`Status ${status} is not valid to create a response`);
@@ -17,15 +17,28 @@ const formatResponses = values => values.reduce((acc, value) => {
       description,
       content: {
         ...(hasOldContent(acc, status) ? { ...acc[status].content } : {}),
-        ...getContent(value.type, contentType, value.description),
+        ...getContent(value.type, contentType, value.description, examples[status]),
       },
     },
   };
 }, {});
 
-const responsesGenerator = (returnValues = []) => {
+const formatExamples = (exampleValues = []) => {
+  return exampleValues.reduce((exampleMap, example, i) => ({
+    ...exampleMap,
+    [example.status]: {
+      ...exampleMap[example.status],
+      [`example${i + 1}`]: {
+        summary: example.summary,
+        value: example.value,
+      },
+    },
+  }), {});
+};
+
+const responsesGenerator = (returnValues = [], exampleValues = []) => {
   if (!returnValues || !Array.isArray(returnValues)) return {};
-  return formatResponses(returnValues);
+  return formatResponses(returnValues, formatExamples(exampleValues));
 };
 
 module.exports = responsesGenerator;


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - ~Bugfix~
 - Feature
 - Test
 - Docs
 - ~Refactor~
 - Build-related changes
 - ~Other, please describe:~

### Description:

This PR adds support for `@example` annotations. These can be used to add examples on the expected input / output for every endpoint of our API. More details on its usage and specifications can be found in the sections listed below.

Should close #89.

### Usage example:

The following example illustrates how the `@example` annotation can be used to add examples on how the request body must be, as well as what the endpoint is supposed to return for specific status codes.

```javascript
/**
 * POST /api/v1/song
 * @param {Song} request.body.required - song info
 * @return {object} 200 - song response
 * @return {object} 400 - Bad request response
 * @example request - example payload
 * {
 *   "title": "untitled song",
 *   "artist": "anonymous",
 *   "year": 2019
 * }
 * @example response - 200 - example success response
 * {
 *   "message": "you have saved song"
 * }
 * @example response - 400 - example error response
 * {
 *   "message": "failed to save song",
 *   "errCode": "E120"
 * }
 */
```

### Usage instructions:

The `@example` annotation must be immediatly be followed by a keyword that will represent what our example will be illustrating: `request` or `response`.

**It's possible to add as many examples as required for both requests and responses in a single endpoint**, there's no limit on that. In the case of responses, multiple examples for the same status code are also supported (so we can provide multiple examples of what our API returns if it succeeds, for example).

The sections below describe more in detail the expected syntax for the `@example` tag in each case (request and responses). Although it's same for the most part, it will differ slightly depending on the keyword used.

#### :inbox_tray: Request body example:

```
@example request - [summary]
[content]
```

| Field | Description |
| --- | --- |
| Summary | Small text that briefly describes the example. This text must occupy a single line. Everything outside of the `@example` tag line will be considered part of the example content and *NOT* the summary. |
| Content | Example content for the request body. It's imperative that its contents start at a new line below the `@example` tag, and not in the same one. The content can be split into multiple lines if necessary, for better readibility. Indentation and breaklines will be preserved in Swagger UI. |

#### :outbox_tray: Response body example:

```
@example response - [status code] - [summary]
[content]
```

| Field | Description |
| --- | --- |
| Summary | Small text that briefly describes the example. This text must occupy a single line. Everything outside of the `@example` tag line will be considered part of the example content and *NOT* the summary. |
| Status code | An HTTP status code (ex.: `200`). Keep in mind that any code not available in [`validStatusCodes`](https://github.com/BRIKEV/express-jsdoc-swagger/blob/master/transforms/paths/validStatusCodes.js) will be ignored. Also, it's necessary for a `@return` tag to exist for that same code in order for the example to appear in Swagger UI. |
| Content | Example content for the response body. It's imperative that its contents start at a new line below the `@example` tag, and not in the same one. The content can be split into multiple lines if necessary, for better readibility. Indentation and breaklines will be preserved in Swagger UI. |

____

### Task list:

:computer: **Development**
- [x] Create parser for `@example` within the `paths` folder.
- [x] Add examples to response objects.
- [x] Add examples to request body objects.
- [x] Create new example in `examples` > `requestBody` folder to illustrate how to use `@example` for the request body.
- [x] Create new example in `examples` > `responses` folder to illustrate how to use `@example` for the responses.

:heavy_check_mark: **Tests**
- [x] Create unit test for `@example` parsing in request body.
- [x] Create unit test for `@example` parsing in responses.

:memo: **Documentation**
- [x] Add descriptive comments to new `examples.js` parser.
- [x] Update `README` file with usage example for the `@example` tag.
- [x] Generate usage instructions for the `@example` tag (included in this PR message).

:whale: **Project settings**
- [x] Update `examples` > `package.json` with references to the new examples.