### PR TITLE
Added options to expose swagger-ui or api-docs separately

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,10 @@ interface Options {
 	filesPattern: string | string[];
 	security?: SecurityObject[];
 	servers?: string[];
+	exposeSwaggerUI?: boolean;
 	swaggerUIPath?: string;
+	exposeApiDocs?: boolean;
+	apiDocsPath?: string;
 }
 
 type UserSwagger = Record<string, unknown>;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ const swaggerEvents = require('./swaggerEvents');
 
 let instance = null;
 const DEFAULT_SWAGGERUI_URL = '/api-docs';
+const DEFAULT_EXPOSE_SWAGGERUI = true;
+const DEFAULT_APIDOCS_URL = '/v3/api-docs';
+const DEFAULT_EXPOSE_APIDOCS = false;
 
 const expressJSDocSwagger = app => {
   if (instance) return () => instance;
@@ -24,14 +27,22 @@ const expressJSDocSwagger = app => {
       })
       .catch(events.error);
 
-    app.use(options.swaggerUIPath || DEFAULT_SWAGGERUI_URL, (req, res, next) => {
-      swaggerObject = {
-        ...swaggerObject,
-        host: req.get('host'),
-      };
-      req.swaggerDoc = swaggerObject;
-      next();
-    }, swaggerUi.serve, swaggerUi.setup());
+    if (options.exposeSwaggerUI || DEFAULT_EXPOSE_SWAGGERUI) {
+      app.use(options.swaggerUIPath || DEFAULT_SWAGGERUI_URL, (req, res, next) => {
+        swaggerObject = {
+          ...swaggerObject,
+          host: req.get('host'),
+        };
+        req.swaggerDoc = swaggerObject;
+        next();
+      }, swaggerUi.serve, swaggerUi.setup());
+    }
+
+    if (options.exposeApiDocs || DEFAULT_EXPOSE_APIDOCS) {
+      app.get(options.apiDocsPath || DEFAULT_APIDOCS_URL, (req, res) => {
+        res.json(swaggerObject);
+      });
+    }
 
     return instance;
   };


### PR DESCRIPTION
Stays fully backwards compatible.

### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:

Added the option to decide whether to expose swagger-ui and api-docs. They can be enabled/disabled separately. Swagger UI is enabled by default to stay backwards compatible. This is the same reason api-docs exposure is disabled by default, because there could be projects, that use `/v3/api-docs` already. 

I would suggest a change in the default swagger ui path though if there will be a major version update, cause the recommended path by swagger is /swagger-ui/index.html or /swagger-ui/. 

This PR would close #114.