### PR TITLE
feat: update swagger events for only current instance

### DIFF
--- a/examples/configuration/multipleInstance.js
+++ b/examples/configuration/multipleInstance.js
@@ -1,0 +1,50 @@
+const express = require("express");
+
+const logger = require("../utils/logger");
+const expressJSDocSwagger = require("../..");
+
+const app = express();
+const port = 3000;
+
+// It is a fictitious configuration
+const optionsClientAPIInstance = {
+  info: {
+    version: "1.0.0",
+    title: "Client API",
+    description: "For client",
+  },
+  filesPattern: "../api/client/v1/*.js",
+  swaggerUIPath: "/api/v1/client/docs",
+  baseDir: __dirname,
+  exposeSwaggerUI: true,
+  exposeApiDocs: true,
+  apiDocsPath: "/api/v1/client/api-docs",
+};
+
+// It is a fictitious configuration
+const optionsAdminAPIInstance = {
+  info: {
+    version: "1.0.0",
+    title: "Admin API",
+    description: "Only admin accounts authorized to use this API",
+  },
+  security: {
+    BearerAuth: {
+      type: "http",
+      scheme: "bearer",
+      bearerFormat: "JWT",
+    },
+  },
+  filesPattern: "../api/admin/v1/*.js",
+  swaggerUIPath: "/api/v1/admin/docs",
+  baseDir: __dirname,
+  exposeSwaggerUI: true,
+  exposeApiDocs: true,
+  apiDocsPath: "/api/v1/admin/api-docs",
+};
+
+expressJSDocSwagger(app)(optionsClientAPIInstance);
+expressJSDocSwagger(app)(optionsAdminAPIInstance);
+
+
+app.listen(port, () => logger.info(`Example app listening at http://localhost:${port}`));

--- a/examples/eventEmitter/multipleInstance.js
+++ b/examples/eventEmitter/multipleInstance.js
@@ -1,0 +1,79 @@
+const express = require("express");
+
+const logger = require("../utils/logger");
+const expressJSDocSwagger = require("../..");
+
+const app = express();
+const port = 3000;
+
+// It is a fictitious configuration
+const optionsClientAPIInstance = {
+  info: {
+    version: "1.0.0",
+    title: "Client API",
+    description: "For client",
+  },
+  filesPattern: "../api/client/v1/*.js",
+  swaggerUIPath: "/api/v1/client/docs",
+  baseDir: __dirname,
+  exposeSwaggerUI: true,
+  exposeApiDocs: true,
+  apiDocsPath: "/api/v1/client/api-docs",
+};
+
+// It is a fictitious configuration
+const optionsAdminAPIInstance = {
+  info: {
+    version: "1.0.0",
+    title: "Admin API",
+    description: "Only admin accounts authorized to use this API",
+  },
+  security: {
+    BearerAuth: {
+      type: "http",
+      scheme: "bearer",
+      bearerFormat: "JWT",
+    },
+  },
+  filesPattern: "../api/admin/v1/*.js",
+  swaggerUIPath: "/api/v1/admin/docs",
+  baseDir: __dirname,
+  exposeSwaggerUI: true,
+  exposeApiDocs: true,
+  apiDocsPath: "/api/v1/admin/api-docs",
+};
+
+const clientAPIInstance = expressJSDocSwagger(app)(optionsClientAPIInstance);
+const adminAPIInstance = expressJSDocSwagger(app)(optionsAdminAPIInstance);
+
+clientAPIInstance.on('error', error => {
+  console.error(`[CLIENT]Error: ${error}`);
+});
+
+clientAPIInstance.on('process', ({ entity, swaggerObject }) => {
+  console.log(`[CLIENT]entity: ${entity}`);
+  console.log('[CLIENT]swaggerObject');
+  console.log(swaggerObject);
+});
+
+clientAPIInstance.on('finish', swaggerObject => {
+  console.log('[CLIENT]Finish');
+  console.log(swaggerObject);
+});
+
+adminAPIInstance.on('error', error => {
+  console.error(`[ADMIN]Error: ${error}`);
+});
+
+adminAPIInstance.on('process', ({ entity, swaggerObject }) => {
+  console.log(`[ADMIN]entity: ${entity}`);
+  console.log('[ADMIN]swaggerObject');
+  console.log(swaggerObject);
+});
+
+adminAPIInstance.on('finish', swaggerObject => {
+  console.log('[ADMIN]Finish');
+  console.log(swaggerObject);
+});
+
+app.listen(port, () => logger.info(`Example app listening at http://localhost:${port}`));

--- a/index.js
+++ b/index.js
@@ -3,49 +3,45 @@ const merge = require('merge');
 const processSwagger = require('./processSwagger');
 const swaggerEvents = require('./swaggerEvents');
 
-let instance = null;
 const DEFAULT_SWAGGERUI_URL = '/api-docs';
 const DEFAULT_EXPOSE_SWAGGERUI = true;
 const DEFAULT_APIDOCS_URL = '/v3/api-docs';
 const DEFAULT_EXPOSE_APIDOCS = false;
 
-const expressJSDocSwagger = app => {
-  if (instance) return () => instance;
-  return (options = {}, userSwagger = {}) => {
-    const events = swaggerEvents();
-    instance = events.instance;
-    let swaggerObject = {};
+const expressJSDocSwagger = app => (options = {}, userSwagger = {}) => {
+  const events = swaggerEvents();
+  const { instance } = events;
+  let swaggerObject = {};
 
-    processSwagger(options, events.processFile)
-      .then(result => {
-        swaggerObject = {
-          ...swaggerObject,
-          ...result,
-        };
-        swaggerObject = merge.recursive(true, swaggerObject, userSwagger);
-        events.finish(swaggerObject);
-      })
-      .catch(events.error);
+  processSwagger(options, events.processFile)
+    .then(result => {
+      swaggerObject = {
+        ...swaggerObject,
+        ...result,
+      };
+      swaggerObject = merge.recursive(true, swaggerObject, userSwagger);
+      events.finish(swaggerObject);
+    })
+    .catch(events.error);
 
-    if (options.exposeSwaggerUI || DEFAULT_EXPOSE_SWAGGERUI) {
-      app.use(options.swaggerUIPath || DEFAULT_SWAGGERUI_URL, (req, res, next) => {
-        swaggerObject = {
-          ...swaggerObject,
-          host: req.get('host'),
-        };
-        req.swaggerDoc = swaggerObject;
-        next();
-      }, swaggerUi.serve, swaggerUi.setup());
-    }
+  if (options.exposeSwaggerUI || DEFAULT_EXPOSE_SWAGGERUI) {
+    app.use(options.swaggerUIPath || DEFAULT_SWAGGERUI_URL, (req, res, next) => {
+      swaggerObject = {
+        ...swaggerObject,
+        host: req.get('host'),
+      };
+      req.swaggerDoc = swaggerObject;
+      next();
+    }, swaggerUi.serve, swaggerUi.setup());
+  }
 
-    if (options.exposeApiDocs || DEFAULT_EXPOSE_APIDOCS) {
-      app.get(options.apiDocsPath || DEFAULT_APIDOCS_URL, (req, res) => {
-        res.json(swaggerObject);
-      });
-    }
+  if (options.exposeApiDocs || DEFAULT_EXPOSE_APIDOCS) {
+    app.get(options.apiDocsPath || DEFAULT_APIDOCS_URL, (req, res) => {
+      res.json(swaggerObject);
+    });
+  }
 
-    return instance;
-  };
+  return instance;
 };
 
 module.exports = expressJSDocSwagger;


### PR DESCRIPTION
doc: add example in configuration -> multipleInstance
doc: add example in eventEmitter -> multipleInstance

It was impossible to create several instances because of the variable
"instance" to instantiate globally and not for the current swagger.
Instance verification condition, blocked the creation of another swagger

### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [X] Feature
 - [ ] Test
 - [X] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:

The creation of a new instance was blocked.
Ability to create multiple swagger instances with their own swaggerEvents.

I added examples of multiple instance in the configuration and eventEmitter folder