### PR TITLE
feat: Added parsing of JSDoc @description tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return {object} 200 - success response
  */
 app.get('/api/v1', (req, res) => res.json({
@@ -102,7 +102,7 @@ const options = {
 ```javascript
 /**
  * GET /api/v1/albums
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @tags album
  * @return {array<Song>} 200 - success response - application/json
  */
@@ -117,7 +117,7 @@ app.get('/api/v1/albums', (req, res) => (
 ```javascript
 /**
  * GET /api/v1/album
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @security BasicAuth
  * @tags album
  * @param {string} name.query.required - name param description
@@ -135,7 +135,7 @@ app.get('/api/v1/album', (req, res) => (
 ```javascript
 /**
  * GET /api/v1/albums
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @tags album
  * @return {array<Song>} 200 - success response - application/json
  * @example response - 200 - success response example

--- a/examples/combineSchemas/index.js
+++ b/examples/combineSchemas/index.js
@@ -38,7 +38,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1/song/{id}
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @tags album
  * @param {number} id.path - song id
  * @return {oneOf|IntrumentalSong|PopSong} 200 - success response - application/json

--- a/examples/configuration/main.js
+++ b/examples/configuration/main.js
@@ -54,7 +54,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return {string} 200 - success response
  */
 app.get('/api/v1', (req, res) => res.send('Hello World!'));

--- a/examples/configuration/multiple-files.txt
+++ b/examples/configuration/multiple-files.txt
@@ -1,5 +1,5 @@
 /**
  * GET /api/v2
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return {string} 200 - success response
  */

--- a/examples/configuration/multipleFiles.js
+++ b/examples/configuration/multipleFiles.js
@@ -54,7 +54,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return {string} 200 - success response
  */
 app.get('/api/v1', (req, res) => res.send('Hello World!'));

--- a/examples/configuration/multipleInstance/admin-v1-docs.js
+++ b/examples/configuration/multipleInstance/admin-v1-docs.js
@@ -1,5 +1,5 @@
 /**
  * GET /api/admin/v1
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return {string} 200 - success response
  */

--- a/examples/configuration/multipleInstance/client-v1-docs.js
+++ b/examples/configuration/multipleInstance/client-v1-docs.js
@@ -1,5 +1,5 @@
 /**
  * GET /api/client/v1
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return {string} 200 - success response
  */

--- a/examples/merge/simple.js
+++ b/examples/merge/simple.js
@@ -31,7 +31,7 @@ expressJSDocSwagger(app)(options, userSwagger);
 
 /**
  * GET /api/v1/albums
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param {array<object>} name.query.required - name param description
  * @return {array<object>} 200 - success response - application/json
  */

--- a/examples/parameters/components.js
+++ b/examples/parameters/components.js
@@ -30,7 +30,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1/albums
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param {array<Song>} name.query.required - name param description
  * @return {array<Song>} 200 - success response - application/json
  */

--- a/examples/parameters/enum.js
+++ b/examples/parameters/enum.js
@@ -22,7 +22,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param {string} name.query.required - name param description - enum:type1,type2
  * @return {string} 200 - success response
  */
@@ -30,7 +30,7 @@ app.get('/api/v1', (req, res) => res.send('Hello World!'));
 
 /**
  * GET /api/v1/albums
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param {string} name.query.required - name param description - enum:type1,type2
  * @param {string} license.query - enum:MIT,ISC - name param description
  * @return {object} 200 - success response - application/json

--- a/examples/parameters/headers.js
+++ b/examples/parameters/headers.js
@@ -22,7 +22,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param {string} name.header.required - name param description
  * @return {string} 200 - success response
  */

--- a/examples/parameters/multiple.js
+++ b/examples/parameters/multiple.js
@@ -22,7 +22,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1/{id}
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param {string} name.query.required - name param description
  * @param {number} id.path - phone number
  * @return {string} 200 - success response
@@ -31,7 +31,7 @@ app.get('/api/v1/:id', (req, res) => res.send('Hello World!'));
 
 /**
  * GET /api/v1/albums/{id}
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param {array<string>} name.query.required.deprecated - name param description
  * @param {number} id.path
  * @return {object} 200 - success response - application/json

--- a/examples/parameters/simple.js
+++ b/examples/parameters/simple.js
@@ -22,7 +22,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param {string} name.query.required - name param description
  * @return {string} 200 - success response
  */
@@ -30,7 +30,7 @@ app.get('/api/v1', (req, res) => res.send('Hello World!'));
 
 /**
  * GET /api/v1/albums
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param {array<string>} name.query.required.deprecated - name param description
  * @return {object} 200 - success response - application/json
  */

--- a/examples/responses/components.js
+++ b/examples/responses/components.js
@@ -30,7 +30,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1/albums
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return {array<Song>} 200 - success response - application/json
  */
 app.get('/api/v1/albums', (req, res) => (

--- a/examples/responses/full-example.js
+++ b/examples/responses/full-example.js
@@ -36,7 +36,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v2/album
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @tags album
  * @security BasicAuth
  * @return {object} 200 - success response - application/json
@@ -50,7 +50,7 @@ app.get('/api/v2/album', (req, res) => (
 
 /**
  * GET /api/v1/album
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @tags album
  * @deprecated
  * @return {object} 200 - success response - application/json
@@ -64,7 +64,7 @@ app.get('/api/v1/album', (req, res) => (
 
 /**
  * GET /api/v1/albums
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @tags album
  * @return {array<Song>} 200 - success response - application/json
  */

--- a/examples/responses/multiple.js
+++ b/examples/responses/multiple.js
@@ -22,7 +22,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1/album
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return {object} 200 - success response - application/json
  * @return {object} 400 - Bad request response
  */

--- a/examples/responses/simple.js
+++ b/examples/responses/simple.js
@@ -22,14 +22,14 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return {string} 200 - success response
  */
 app.get('/api/v1', (req, res) => res.send('Hello World!'));
 
 /**
  * GET /api/v1/albums
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return {object} 200 - success response - application/json
  * @return {array<object>} 200 - success response - application/json
  */

--- a/examples/security/basic-auth.js
+++ b/examples/security/basic-auth.js
@@ -28,7 +28,7 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return {string} 200 - success response
  * @security BasicAuth
  */

--- a/examples/ts-example/simple.ts
+++ b/examples/ts-example/simple.ts
@@ -57,7 +57,7 @@ const options = {
 expressJSDocSwagger(app)(options);
 /**
  * GET /api/v1
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return {string} 200 - success response
  */
 app.get('/api/v1', (req, res) => {

--- a/test/e2e/errors/jsdoc-parameter-error.js
+++ b/test/e2e/errors/jsdoc-parameter-error.js
@@ -1,6 +1,6 @@
 /**
  * GET /api/v1/album
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param name.query.required - name param description
  * @param phone.param - phone number
  * @return {string} 200 - success response

--- a/test/e2e/errors/jsdoc-requestBody-error.js
+++ b/test/e2e/errors/jsdoc-requestBody-error.js
@@ -1,6 +1,6 @@
 /**
  * GET /api/v1/album
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param {object} body.body.required - name param description
  * @return {string} 200 - success response
  */

--- a/test/e2e/errors/jsdoc-response-error.js
+++ b/test/e2e/errors/jsdoc-response-error.js
@@ -1,6 +1,6 @@
 /**
  * GET /api/v1/album
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @return 200 - success response - application/json
  * @return 400 - Bad request response
  */

--- a/test/e2e/parameters/jsdoc-example.js
+++ b/test/e2e/parameters/jsdoc-example.js
@@ -1,6 +1,6 @@
 /**
  * GET /api/v1
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param {string} name.path.required - name param description
  * @param {number} phone.path.required - phone number
  * @return {string} 200 - success response
@@ -8,7 +8,7 @@
 
 /**
  * GET /api/v1/albums
- * @summary This is the summary or description of the endpoint
+ * @summary This is the summary of the endpoint
  * @param {array<string>} name.path.required - name param description
  * @param {number} phone.path.required
  * @return {object} 200 - success response - application/json

--- a/test/e2e/parameters/parameters.test.js
+++ b/test/e2e/parameters/parameters.test.js
@@ -28,7 +28,7 @@ test('should parse components jsdoc from jsdoc-example', async () => {
       '/api/v1': {
         get: {
           deprecated: false,
-          summary: 'This is the summary or description of the endpoint',
+          summary: 'This is the summary of the endpoint',
           responses: {
             200: {
               description: 'success response',
@@ -70,7 +70,7 @@ test('should parse components jsdoc from jsdoc-example', async () => {
       '/api/v1/albums': {
         get: {
           deprecated: false,
-          summary: 'This is the summary or description of the endpoint',
+          summary: 'This is the summary of the endpoint',
           responses: {
             200: {
               description: 'success response',

--- a/test/transforms/paths/combineSchemas.test.js
+++ b/test/transforms/paths/combineSchemas.test.js
@@ -6,7 +6,7 @@ test('should parse jsdoc path response with oneOf keyword', () => {
   const jsodInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {oneOf|Song|Album} 200 - success response - application/json
        */
     `];
@@ -15,7 +15,7 @@ test('should parse jsdoc path response with oneOf keyword', () => {
       '/api/v1': {
         get: {
           deprecated: false,
-          summary: 'This is the summary or description of the endpoint',
+          summary: 'This is the summary of the endpoint',
           parameters: [],
           tags: [],
           security: [],
@@ -52,7 +52,7 @@ test('should not parse when type is invalid', () => {
   const jsodInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {invalid|Song|Album} 200 - success response - application/json
        */
     `];
@@ -61,7 +61,7 @@ test('should not parse when type is invalid', () => {
       '/api/v1': {
         get: {
           deprecated: false,
-          summary: 'This is the summary or description of the endpoint',
+          summary: 'This is the summary of the endpoint',
           parameters: [],
           tags: [],
           security: [],

--- a/test/transforms/paths/index.test.js
+++ b/test/transforms/paths/index.test.js
@@ -22,11 +22,12 @@ describe('setPaths method', () => {
     expect(result).toEqual(expected);
   });
 
-  it('should parse jsdoc path spec with one response, summary and endpoint info', () => {
+  it('should parse jsdoc path spec with one response, summary, description and endpoint info', () => {
     const jsodInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
+       * @description This is the description of the endpoint
        * @return {object} 200 - success response - application/json
        */
     `];
@@ -35,7 +36,8 @@ describe('setPaths method', () => {
         '/api/v1': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
+            description: 'This is the description of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -65,7 +67,7 @@ describe('setPaths method', () => {
       /**
        * GET /api/v1
        * @deprecated
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {object} 200 - success response - application/json
        */
     `];
@@ -74,7 +76,7 @@ describe('setPaths method', () => {
         '/api/v1': {
           get: {
             deprecated: true,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -104,14 +106,14 @@ describe('setPaths method', () => {
       /**
        * GET /api/v1
        * @deprecated
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {object} 200 - success response - application/json
        */
     `,
     `
       /**
        * GET /api/v1/songs
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {object} 200 - success response - application/json
        */
     `];
@@ -120,7 +122,7 @@ describe('setPaths method', () => {
         '/api/v1': {
           get: {
             deprecated: true,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -141,7 +143,7 @@ describe('setPaths method', () => {
         '/api/v1/songs': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -171,14 +173,14 @@ describe('setPaths method', () => {
       /**
        * GET /api/v1
        * @deprecated
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {object} 200 - success response - application/json
        */
     `,
     `
       /**
        * POST /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {object} 200 - success response - application/json
        */
     `];
@@ -187,7 +189,7 @@ describe('setPaths method', () => {
         '/api/v1': {
           get: {
             deprecated: true,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -206,7 +208,7 @@ describe('setPaths method', () => {
           },
           post: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],

--- a/test/transforms/paths/responses.test.js
+++ b/test/transforms/paths/responses.test.js
@@ -7,7 +7,7 @@ describe('response tests', () => {
     const jsodInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {object} 200 - success response - application/json
        * @return {object} 400 - Bad request response
        */
@@ -17,7 +17,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -61,7 +61,7 @@ describe('response tests', () => {
     const jsodInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {object} 200 success response - application/json
        */
     `];
@@ -70,7 +70,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             responses: {},
             parameters: [],
             tags: [],
@@ -96,7 +96,7 @@ describe('response tests', () => {
     const jsodInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {object} default - success response - application/json
        */
     `];
@@ -105,7 +105,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -139,7 +139,7 @@ describe('response tests', () => {
     const jsodInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {array<integer>} 200 - success response - application/json
        */
     `];
@@ -148,7 +148,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -181,7 +181,7 @@ describe('response tests', () => {
     const jsodInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {Song} 200 - success response - application/json
        */
     `];
@@ -190,7 +190,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -220,7 +220,7 @@ describe('response tests', () => {
     const jsodInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {array<Song>} 200 - success response - application/json
        */
     `];
@@ -229,7 +229,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -262,7 +262,7 @@ describe('response tests', () => {
     const jsodInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {object} 200 - success response - application/json
        * @return {object} 400 - Bad request response
        * @return {string} 400 - Bad request response - application/xml
@@ -273,7 +273,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -318,7 +318,7 @@ describe('response tests', () => {
     const jsdocInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {Song} 200 - success response - application/json
        * @return {object} 403 - forbidden response - application/json
        * @example response - 200 - example success response
@@ -337,7 +337,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -394,7 +394,7 @@ describe('response tests', () => {
     const jsdocInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {Song} 200 - success response - application/json
        * @return {object} 403 - forbidden response - application/json
        * @example response - 200 - example success response
@@ -429,7 +429,7 @@ describe('response tests', () => {
     const jsdocInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {Song} 200 - success response - application/json
        * @return {object} 403 - forbidden response - application/json
        * @example response - 200 - example success response
@@ -448,7 +448,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -498,7 +498,7 @@ describe('response tests', () => {
     const jsdocInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {Song} 200 - success response - application/json
        * @return {object} 403 - forbidden response - application/json
        * @example response - 200 - example success response
@@ -517,7 +517,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],
@@ -565,7 +565,7 @@ describe('response tests', () => {
     const jsodInput = [`
       /**
        * GET /api/v1
-       * @summary This is the summary or description of the endpoint
+       * @summary This is the summary of the endpoint
        * @return {array<Song|Song>} 200 - success response - application/json
        */
     `];
@@ -574,7 +574,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
-            summary: 'This is the summary or description of the endpoint',
+            summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
             security: [],

--- a/transforms/paths/index.js
+++ b/transforms/paths/index.js
@@ -19,6 +19,8 @@ const formatSecurity = (securityValues = []) => securityValues.map(({ descriptio
 
 const formatSummary = summary => (summary || {}).description || '';
 
+const formatDescription = description => (description || {}).description || undefined;
+
 const setRequestBody = (lowerCaseMethod, bodyValues, requestExamples) => {
   const hasBodyValues = bodyValues.length > 0;
   const requestBody = requestBodyGenerator(bodyValues, requestExamples);
@@ -32,6 +34,7 @@ const pathValues = tags => {
   const examples = examplesGenerator(examplesValues);
 
   const summary = getTagInfo(tags, 'summary');
+  const description = getTagInfo(tags, 'description');
   const deprecated = getTagInfo(tags, 'deprecated');
   const isDeprecated = !!deprecated;
   /* Response info */
@@ -49,6 +52,7 @@ const pathValues = tags => {
   const bodyValues = paramValues.filter(bodyParams);
   return {
     summary,
+    description,
     isDeprecated,
     responses,
     parameters,
@@ -67,7 +71,15 @@ const parsePath = (path, state) => {
   if (!validHTTPMethod(lowerCaseMethod)) return {};
   const { tags } = path;
   const {
-    summary, bodyValues, isDeprecated, responses, parameters, tagsValues, securityValues, examples,
+    summary,
+    description,
+    bodyValues,
+    isDeprecated,
+    responses,
+    parameters,
+    tagsValues,
+    securityValues,
+    examples,
   } = pathValues(tags);
   const requestExamples = examples.filter(example => example.type === 'request');
   return {
@@ -77,6 +89,7 @@ const parsePath = (path, state) => {
       [lowerCaseMethod]: {
         deprecated: isDeprecated,
         summary: formatSummary(summary),
+        description: formatDescription(description),
         security: formatSecurity(securityValues),
         responses,
         parameters,


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [x] Feature
 - [x] Test
 - [x] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:

Adds support for the `@description` tag so that you can provide longer descriptions for API endpoints while summarizing with the `@summary` tag. Adapted one of the tests to have a simple verification and ran a global-replace of `summary or description` => `summary` which resulted in quite a diff. 

_Offtopic: A big thanks to everyone contributing here by the way, we're using `express-jsdoc-swagger` to generate OpenAPI specs that a Node process writes to a file that in turn Redocly uses to display it within a documentation portal 🙌 Like the way it's made to be a good fit for REST APIs while still adhering to the JSDoc standards_