### PR TITLE
fix: multiple data types without swagger keywords

### DIFF
--- a/examples/nullableFields/index.js
+++ b/examples/nullableFields/index.js
@@ -27,6 +27,7 @@ expressJSDocSwagger(app)(options);
  * @property {string} artist - The artist
  * @property {integer} year - The year - int64
  * @property {oneOf|string|null} album - The album to which the song belongs (if any)
+ * @property {(string[]|null)} tags - Associate tags (if any)
  */
 
 /**

--- a/test/transforms/paths/combineSchemas.test.js
+++ b/test/transforms/paths/combineSchemas.test.js
@@ -233,3 +233,63 @@ test('should parse component with anyOf array keyword', () => {
   const result = parseComponents({}, parsedJSDocs);
   expect(result).toEqual(expected);
 });
+
+test('should parse component with jsdoc syntax for multiple data types', () => {
+  const jsodInput = [`
+    /**
+     * A song
+     * @typedef {object} Song
+     * @property {string} title.required
+     * @property {string} artist
+     * @property {number} year
+     * @property {(string|null)} album
+     * @property {object|number} releaseDate
+     */
+  `];
+  const expected = {
+    components: {
+      schemas: {
+        Song: {
+          type: 'object',
+          required: [
+            'title',
+          ],
+          description: 'A song',
+          properties: {
+            title: {
+              type: 'string',
+              description: '',
+            },
+            artist: {
+              type: 'string',
+              description: '',
+            },
+            year: {
+              type: 'number',
+              description: '',
+            },
+            album: {
+              type: 'string',
+              description: '',
+              nullable: true,
+            },
+            releaseDate: {
+              description: '',
+              oneOf: [
+                {
+                  type: 'object',
+                },
+                {
+                  type: 'number',
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  };
+  const parsedJSDocs = jsdocInfo()(jsodInput);
+  const result = parseComponents({}, parsedJSDocs);
+  expect(result).toEqual(expected);
+});

--- a/test/transforms/paths/combineSchemas.test.js
+++ b/test/transforms/paths/combineSchemas.test.js
@@ -47,46 +47,7 @@ test('should parse jsdoc path response with oneOf keyword', () => {
   expect(result).toEqual(expected);
 });
 
-test('should not parse when type is invalid', () => {
-  global.console = { ...global.console, warn: jest.fn() };
-  const jsodInput = [`
-      /**
-       * GET /api/v1
-       * @summary This is the summary of the endpoint
-       * @return {invalid|Song|Album} 200 - success response - application/json
-       */
-    `];
-  const expected = {
-    paths: {
-      '/api/v1': {
-        get: {
-          deprecated: false,
-          summary: 'This is the summary of the endpoint',
-          parameters: [],
-          tags: [],
-          security: [],
-          responses: {
-            200: {
-              description: 'success response',
-              content: {
-                'application/json': {
-                  schema: {},
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  };
-  const parsedJSDocs = jsdocInfo()(jsodInput);
-  const result = setPaths({}, parsedJSDocs);
-  expect(result).toEqual(expected);
-  // eslint-disable-next-line
-  expect(console.warn).toHaveBeenCalled();
-});
-
-test('should not parse component with anyOf keyword', () => {
+test('should parse component with anyOf keyword', () => {
   const jsodInput = [`
     /**
      * A song
@@ -193,7 +154,8 @@ test('should parse jsdoc path reference params with allOf keyword', () => {
   const result = setPaths({}, parsedJSDocs);
   expect(result).toEqual(expected);
 });
-test('should not parse component with anyOf array keyword', () => {
+
+test('should parse component with anyOf array keyword', () => {
   const jsodInput = [`
     /**
      * A song


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Bugfix
 - [ ] Feature
 - [X] Test
 - [X] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:

When parsing properties with multiple data types, there was an issue if the user did not add one of the Swagger keywords (`oneOf`, `anyOf` or `allOf`) as the first item in the list, for example:

```
/**
 * @typedef {object} Song
 * @property {string} title.required
 * @property {string} artist
 * @property {number} year
 * @property {object|number} releaseDate
 */
```

In this scenario, the generated schema for the `releaseDate` property would only contain the second type:

```
{
  'description': '',
  'type': 'number',
}
```

As the library assumed the first item to be a keyword and not a real type, the `object` type would be completely ignored and not appear into the generated schema. 

This PR fixes this issue, making the usage of `oneOf`, `anyOf` or `allOf` keywords optional. If the user chooses to write the different data types without specifying a keyword, the **behaviour of `oneOf` will be assumed by default**. 

### Task list:

:bug: **Bug**
- [x] If first item of the data type list is not a keyword, iterate trough the whole `elements` array instead of excluding the first. 

:heavy_check_mark: **Test**
- [x] Fix description for some test in `combineSchema.test.js`.
- [x] Add new test to validate schemas for properties with multiple types written in vanilla JSDoc syntax. 

:arrows_counterclockwise: **Refactor**
- [x] Remove test that forced the first item in data type list to be a Swagger keyword. 

:memo: **Documentation**
- [x] Add JSDoc comments to methods in `combineSchema.js`.