### PR TITLE
Docs/update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,19 @@ const options = {
       scheme: 'basic',
     },
   },
-  filesPattern: './**/*.js', // Glob pattern to find your jsdoc files (it supports arrays too ['./**/*.controller.js', './**/*.route.js'])
-  swaggerUIPath: '/your-url', // SwaggerUI will be render in this url. Default: '/api-docs'
   baseDir: __dirname,
-  exposeSwaggerUI: true, // Expose OpenAPI UI. Default true
-  exposeApiDocs: false, // Expose Open API JSON Docs documentation in `apiDocsPath` path. Default false.
-  apiDocsPath: '/v3/api-docs', // Open API JSON Docs endpoint. Default value '/v3/api-docs'.
-  notRequiredAsNullable: false, // Set non-required fields as nullable by default
+  // Glob pattern to find your jsdoc files (multiple patterns can be added in an array)
+  filesPattern: './**/*.js',
+  // URL where SwaggerUI will be rendered
+  swaggerUIPath: '/api-docs',
+  // Expose OpenAPI UI
+  exposeSwaggerUI: true,
+  // Expose Open API JSON Docs documentation in `apiDocsPath` path.
+  exposeApiDocs: false,
+  // Open API JSON Docs endpoint.
+  apiDocsPath: '/v3/api-docs',
+  // Set non-required fields as nullable by default
+  notRequiredAsNullable: false,
 };
 
 const app = express();
@@ -83,8 +89,19 @@ const options = {
       scheme: 'basic',
     },
   },
-  filesPattern: './**/*.js', // Glob pattern to find your jsdoc files
   baseDir: __dirname,
+  // Glob pattern to find your jsdoc files (multiple patterns can be added in an array)
+  filesPattern: './**/*.js',
+  // URL where SwaggerUI will be rendered
+  swaggerUIPath: '/api-docs',
+  // Expose OpenAPI UI
+  exposeSwaggerUI: true,
+  // Expose Open API JSON Docs documentation in `apiDocsPath` path.
+  exposeApiDocs: false,
+  // Open API JSON Docs endpoint.
+  apiDocsPath: '/v3/api-docs',
+  // Set non-required fields as nullable by default
+  notRequiredAsNullable: false,
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ const options = {
   apiDocsPath: '/v3/api-docs',
   // Set non-required fields as nullable by default
   notRequiredAsNullable: false,
+  // You can customize your UI options.
+  // you can extend swagger-ui-express config. You can checkout an example of this
+  // in the `example/configuration/swaggerOptions.js`
+  swaggerUiOptions: {},
 };
 
 const app = express();
@@ -69,7 +73,6 @@ app.get('/api/v1', (req, res) => res.json({
 }));
 
 app.listen(PORT, () => console.log(`Example app listening at http://localhost:${PORT}`));
-
 ```
 
 ## Examples
@@ -92,16 +95,6 @@ const options = {
   baseDir: __dirname,
   // Glob pattern to find your jsdoc files (multiple patterns can be added in an array)
   filesPattern: './**/*.js',
-  // URL where SwaggerUI will be rendered
-  swaggerUIPath: '/api-docs',
-  // Expose OpenAPI UI
-  exposeSwaggerUI: true,
-  // Expose Open API JSON Docs documentation in `apiDocsPath` path.
-  exposeApiDocs: false,
-  // Open API JSON Docs endpoint.
-  apiDocsPath: '/v3/api-docs',
-  // Set non-required fields as nullable by default
-  notRequiredAsNullable: false,
 };
 ```
 

--- a/examples/configuration/swaggerOptions.js
+++ b/examples/configuration/swaggerOptions.js
@@ -1,0 +1,56 @@
+const express = require('express');
+
+const logger = require('../utils/logger');
+const expressJSDocSwagger = require('../..');
+
+// This is a full set of options
+// It is not neccesary to complete every option
+const options = {
+  info: {
+    version: '1.0.0',
+    title: 'Albums store',
+    license: {
+      name: 'MIT',
+      url: 'http://example.com',
+    },
+    description: 'API desctiption',
+    contact: {
+      name: 'contact name',
+      url: 'http://example.com',
+      email: 'test@test.com',
+    },
+    termsOfService: 'http://example.com',
+  },
+  servers: [],
+  filesPattern: './main.js',
+  baseDir: __dirname,
+  swaggerUiOptions: {
+    swaggerOptions: {
+      // This one removes the modals spec
+      // You can checkout more config info here: https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md
+      defaultModelsExpandDepth: -1,
+    },
+  },
+};
+
+const app = express();
+const port = 3000;
+
+expressJSDocSwagger(app)(options);
+
+/**
+ * A song type
+ * @typedef {object} Song
+ * @property {string} title.required - The title
+ * @property {string} artist - The artist
+ * @property {integer} year - The year - int64
+ */
+
+/**
+ * GET /api/v1/albums
+ * @summary This is the summary of the endpoint
+ * @return {array<Song>} 200 - success response - application/json
+ */
+app.get('/api/v1/albums', (req, res) => res.json([]));
+
+app.listen(port, () => logger.info(`Example app listening at http://localhost:${port}`));

--- a/examples/package.json
+++ b/examples/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "configuration:main": "node configuration/main.js",
     "configuration:multipleFiles": "node configuration/multipleFiles.js",
+    "configuration:swaggerOptions": "node configuration/swaggerOptions.js",
     "configuration:multipleInstance": "node configuration/multipleInstance/index.js",
     "parameters:simple": "node parameters/simple.js",
     "parameters:headers": "node parameters/headers.js",


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Docs

### Description:
This PR adds better docs when you want to extend swagger-ui-express options. This [PR](https://github.com/BRIKEV/express-jsdoc-swagger/pull/139) includes the option to extend swagger UI but it is not very clear how to send the options to the swagger-ui-express https://github.com/scottie1984/swagger-ui-express/blob/master/index.js#L142 as we have to send and object. Therfore, we add an example to illustrate this.

This closes #137 
