### PR TITLE
feat: remove warning with different types

### DIFF
--- a/transforms/utils/combineSchema.js
+++ b/transforms/utils/combineSchema.js
@@ -1,4 +1,3 @@
-const errorMessage = require('./errorMessage');
 const { refSchema } = require('./refSchema');
 
 const VALID_TYPES = ['oneOf', 'anyOf', 'allOf'];
@@ -15,7 +14,6 @@ const getUnionType = elements => {
   const unionType = elements[0].name;
 
   if (!VALID_TYPES.includes(unionType)) {
-    errorMessage(`unionType ${unionType} invalid, it should be one of these ${VALID_TYPES.join(', ')}`);
     return null;
   }
 


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Feature

### Description:
This feature removes the warning message as we are providing support to multiple types with this notation `{string|null}`. We don't need to warn about using `anyOf`, `oneOf` or any OpenAPI reserved word.

