### PR TITLE
feat: add support for `@returns` tag

### DIFF
--- a/test/transforms/paths/responses.test.js
+++ b/test/transforms/paths/responses.test.js
@@ -53,6 +53,56 @@ describe('response tests', () => {
       .toEqual(expected);
   });
 
+  it('should parse jsdoc with responses, whether @return or @returns tags are used', () => {
+    const jsdocInput = [`
+      /**
+       * GET /api/v1
+       * @summary This is the summary of the endpoint
+       * @return {object} 200 - success response - application/json
+       * @returns {object} 400 - Bad request response
+       */
+    `];
+    const expected = {
+      paths: {
+        '/api/v1': {
+          get: {
+            deprecated: false,
+            summary: 'This is the summary of the endpoint',
+            parameters: [],
+            tags: [],
+            security: [],
+            responses: {
+              200: {
+                description: 'success response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+              400: {
+                description: 'Bad request response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsdocInput);
+    const result = setPaths({}, parsedJSDocs);
+    expect(result)
+      .toEqual(expected);
+  });
+
   it('should not parse jsdoc with wrong info and return warning in the console', () => {
     global.console = {
       ...global.console,

--- a/transforms/paths/index.js
+++ b/transforms/paths/index.js
@@ -38,7 +38,10 @@ const pathValues = tags => {
   const deprecated = getTagInfo(tags, 'deprecated');
   const isDeprecated = !!deprecated;
   /* Response info */
-  const returnValues = getTagsInfo(tags, 'return');
+  const returnValues = [
+    ...getTagsInfo(tags, 'return'),
+    ...getTagsInfo(tags, 'returns'),
+  ];
   const responseExamples = examples.filter(example => example.type === 'response');
   const responses = responsesGenerator(returnValues, responseExamples);
   /* Parameters info */


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [x] Feature
 - [x] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:
JSDocs provides a [`@returns` tag](https://jsdoc.app/tags-returns.html) with the same meaning as `@return`. This PR adds support to this tag, so both `@return` and `@returns` can be used to document the output of an endpoint. 