### PR TITLE
docs: update readme with validator example

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,114 @@ app.get('/api/v1/albums', (req, res) => (
 
 You can find more examples [here](https://github.com/BRIKEV/express-jsdoc-swagger/tree/master/examples), or visit our [documentation](https://brikev.github.io/express-jsdoc-swagger-docs/#/).
 
+## Validator
+
+We developed a new package works as a validator of your API endpoints and the documentation you create with this package. This package is [express-oas-validator](https://github.com/BRIKEV/express-oas-validator).
+
+**Example**
+
+Install using the node package registry:
+
+```
+npm install --save express-oas-validator
+```
+
+After this you have to initialize using the `finish` event. More info in this [sections](eventEmitter.md).
+
+```js
+const instance = expressJSDocSwagger(app)(options);
+
+instance.on('finish', data => {
+  init(data);
+  resolve(app);
+});
+```
+
+This is a full example of how it works.
+
+```js
+const express = require('express');
+const expressJSDocSwagger = require('express-jsdoc-swagger');
+const { init, validateRequest, validateResponse } = require('express-oas-validator');
+
+const options = {
+  info: {
+    version: '1.0.0',
+    title: 'Albums store',
+    license: {
+      name: 'MIT',
+    },
+  },
+  filesPattern: './**.js',
+  baseDir: __dirname,
+};
+
+const app = express();
+const instance = expressJSDocSwagger(app)(options);
+
+const serverApp = () => new Promise(resolve => {
+  instance.on('finish', data => {
+    init(data);
+    resolve(app);
+  });
+
+  app.use(express.urlencoded({ extended: true }));
+  app.use(express.json());
+
+  /**
+   * A song
+   * @typedef {object} Song
+   * @property {string} title.required - The title
+   * @property {string} artist - The artist
+   * @property {integer} year - The year
+   */
+
+  /**
+   * POST /api/v1/songs
+   * @param {Song} request.body.required - song info
+   * @return {object} 200 - song response
+   */
+  app.post('/api/v1/songs', validateRequest(), (req, res) => res.send('You save a song!'));
+
+  /**
+   * POST /api/v1/name
+   * @param {string} request.body.required - name body description
+   * @return {object} 200 - song response
+   */
+  app.post('/api/v1/name', (req, res, next) => {
+    try {
+      // Validate response
+      validateResponse('Error string', req);
+      return res.send('Hello World!');
+    } catch (error) {
+      return next(error);
+    }
+  });
+
+  /**
+   * GET /api/v1/authors
+   * @summary This is the summary or description of the endpoint
+   * @param {string} name.query.required - name param description - enum:type1,type2
+   * @param {array<string>} license.query - name param description
+   * @return {object} 200 - success response - application/json
+   */
+  app.get('/api/v1/authors', validateRequest({ headers: false }), (req, res) => (
+    res.json([{
+      title: 'album 1',
+    }])
+  ));
+
+  // eslint-disable-next-line no-unused-vars
+  app.use((err, req, res, next) => {
+    res.status(err.status).json(err);
+  });
+});
+
+module.exports = serverApp;
+```
+
+You can visit our [documentation](https://brikev.github.io/express-jsdoc-swagger-docs/#/validator).
+
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Docs


### Description:
This PR includes `express-oas-validator` example in the readme so that people can use the advantages of this package mixed with the `express-jsdoc-swagger`.
