### PR TITLE
Feat/multiple security config

### DIFF
--- a/examples/security/basic-auth.js
+++ b/examples/security/basic-auth.js
@@ -16,6 +16,10 @@ const options = {
       type: 'http',
       scheme: 'basic',
     },
+    BearerAuth: {
+      type: 'http',
+      scheme: 'bearer',
+    },
   },
   filesPattern: './basic-auth.js',
   baseDir: __dirname,
@@ -28,10 +32,26 @@ expressJSDocSwagger(app)(options);
 
 /**
  * GET /api/v1
- * @summary This is the summary of the endpoint
+ * @summary Endpoint with security info
  * @return {string} 200 - success response
  * @security BasicAuth
  */
 app.get('/api/v1', (req, res) => res.send('Hello World!'));
+
+/**
+ * GET /api/v2
+ * @summary Endpoint with multiple security configuration (AND logic)
+ * @return {string} 200 - success response
+ * @security BasicAuth & BearerAuth
+ */
+app.get('/api/v2', (req, res) => res.send('Hello World!'));
+
+/**
+ * GET /api/v3
+ * @summary Endpoint with multiple security configuration (OR logic)
+ * @return {string} 200 - success response
+ * @security BasicAuth | BearerAuth
+ */
+app.get('/api/v3', (req, res) => res.send('Hello World!'));
 
 app.listen(port, () => logger.info(`Example app listening at http://localhost:${port}`));

--- a/test/transforms/paths/security.test.js
+++ b/test/transforms/paths/security.test.js
@@ -32,4 +32,106 @@ describe('Paths - security', () => {
     const result = setPaths({}, parsedJSDocs);
     expect(result).toEqual(expected);
   });
+
+  it('Should parse jsdoc multiple security params into security array with each security type', () => {
+    const jsodInput = [`
+      /**
+       * POST /api/v1/song
+       * @summary Create new song
+       * @security BasicAuth
+       * @security BearerAuth
+       */
+    `];
+    const expected = {
+      paths: {
+        '/api/v1/song': {
+          post: {
+            deprecated: false,
+            summary: 'Create new song',
+            security: [
+              {
+                BasicAuth: [],
+              },
+              {
+                BearerAuth: [],
+              },
+            ],
+            tags: [],
+            responses: {},
+            parameters: [],
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = setPaths({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
+
+  it('Should parse jsdoc multiple security with "and" configuration', () => {
+    const jsodInput = [`
+      /**
+       * POST /api/v1/song
+       * @summary Create new song
+       * @security BasicAuth & BearerAuth
+       */
+    `];
+    const expected = {
+      paths: {
+        '/api/v1/song': {
+          post: {
+            deprecated: false,
+            summary: 'Create new song',
+            security: [
+              {
+                BasicAuth: [],
+                BearerAuth: [],
+              },
+            ],
+            tags: [],
+            responses: {},
+            parameters: [],
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = setPaths({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
+
+  it('Should parse jsdoc multiple security with "or" configuration', () => {
+    const jsodInput = [`
+      /**
+       * POST /api/v1/song
+       * @summary Create new song
+       * @security BasicAuth & BearerAuth | Oauth2
+       */
+    `];
+    const expected = {
+      paths: {
+        '/api/v1/song': {
+          post: {
+            deprecated: false,
+            summary: 'Create new song',
+            security: [
+              {
+                BasicAuth: [],
+                BearerAuth: [],
+              },
+              {
+                Oauth2: [],
+              },
+            ],
+            tags: [],
+            responses: {},
+            parameters: [],
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = setPaths({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
 });

--- a/transforms/paths/index.js
+++ b/transforms/paths/index.js
@@ -7,15 +7,12 @@ const {
   validRequestBodyMethods: bodyMethods,
   validHTTPMethod,
 } = require('../utils/httpMethods');
+const formatSecurity = require('./security');
 
 const formatTags = (tags = []) => tags.map(({ description }) => {
   const { name } = formatDescriptionTag(description);
   return name;
 });
-
-const formatSecurity = (securityValues = []) => securityValues.map(({ description }) => ({
-  [description]: [],
-}));
 
 const formatSummary = summary => (summary || {}).description || '';
 

--- a/transforms/paths/security.js
+++ b/transforms/paths/security.js
@@ -1,0 +1,29 @@
+const { flatArray } = require('../utils/arrays');
+
+const AND_SEPARATOR = ' & ';
+const OR_SEPARATOR = ' | ';
+
+const formatOrValues = ({ description }) => {
+  const securityNames = description.split(OR_SEPARATOR);
+  return securityNames.map(names => ({
+    description: names,
+  }));
+};
+
+const formatSecurity = (securityValues = []) => (
+  flatArray(securityValues
+    .map(formatOrValues))
+    .map(({ description }) => {
+      const securityNames = description.split(AND_SEPARATOR);
+      return {
+        ...securityNames.reduce((acum, names) => (
+          {
+            ...acum,
+            [names]: [],
+          }
+        ), {}),
+      };
+    })
+);
+
+module.exports = formatSecurity;


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Feature
 - [X] Test
 - [X] Docs

### Description:
This PR adds different ways to define security headers in the OpenApi Docs. This is based on this [doc](https://swagger.io/docs/specification/authentication/)

We defined multiple ways to define it.

1. Basic one

```
/**
 * GET /api/v1
 ....
 * @security BasicAuth
 */
```

2. Multiple (AND condition)

```
/**
 * GET /api/v2
 ....
 * @security BasicAuth & BearerAuth
 */
```

2. Multiple (OR condition)

```
/**
 * GET /api/v3
 ....
 * @security BasicAuth | BearerAuth
 */

/**
 * GET /api/v4
 ....
 * @security BearerAuth
 * @security BasicAuth
 */
```

This closes #157 
