### PR TITLE
Feat/add empty responses

### DIFF
--- a/test/e2e/errors/errors.test.js
+++ b/test/e2e/errors/errors.test.js
@@ -2,31 +2,6 @@
 const chalk = require('chalk');
 const processSwagger = require('../../../processSwagger');
 
-test('should give a nice error message for responses', async () => {
-  const options = {
-    info: {
-      version: '1.0.0',
-      title: 'Albums store',
-      license: {
-        name: 'MIT',
-      },
-    },
-    filesPattern: './jsdoc-response-error.js',
-    baseDir: __dirname,
-  };
-  global.console = { ...global.console, warn: jest.fn() };
-  await processSwagger(options);
-  expect(console.warn).toHaveBeenCalledTimes(2);
-  expect(console.warn).toHaveBeenNthCalledWith(
-    1,
-    chalk.yellow('[express-jsdoc-swagger] Entity: @return could not be parsed. Value: "200 - success response - application/json" is wrong'),
-  );
-  expect(console.warn).toHaveBeenNthCalledWith(
-    2,
-    chalk.yellow('[express-jsdoc-swagger] Entity: @return could not be parsed. Value: "400 - Bad request response" is wrong'),
-  );
-});
-
 test('should give a nice error message for parameters', async () => {
   const options = {
     info: {

--- a/test/e2e/errors/jsdoc-response-error.js
+++ b/test/e2e/errors/jsdoc-response-error.js
@@ -1,6 +1,0 @@
-/**
- * GET /api/v1/album
- * @summary This is the summary of the endpoint
- * @return 200 - success response - application/json
- * @return 400 - Bad request response
- */

--- a/test/transforms/paths/responses.test.js
+++ b/test/transforms/paths/responses.test.js
@@ -3,6 +3,42 @@ const jsdocInfo = require('../../../consumers/jsdocInfo');
 const setPaths = require('../../../transforms/paths');
 
 describe('response tests', () => {
+  it('should parse jsdoc path spec with more than one response without type', () => {
+    const jsodInput = [`
+      /**
+       * GET /api/v1
+       * @summary This is the summary of the endpoint
+       * @return 200 - success response - application/json
+       * @return 400 - Bad request response
+       */
+    `];
+    const expected = {
+      paths: {
+        '/api/v1': {
+          get: {
+            deprecated: false,
+            summary: 'This is the summary of the endpoint',
+            parameters: [],
+            tags: [],
+            security: [],
+            responses: {
+              200: {
+                description: 'success response',
+              },
+              400: {
+                description: 'Bad request response',
+              },
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = setPaths({}, parsedJSDocs);
+    expect(result)
+      .toEqual(expected);
+  });
+
   it('should parse jsdoc path spec with more than one response', () => {
     const jsodInput = [`
       /**

--- a/transforms/paths/responses.js
+++ b/transforms/paths/responses.js
@@ -25,10 +25,12 @@ const formatResponses = (values, examples) => values.reduce((acc, value) => {
     ...acc,
     [status]: {
       description,
-      content: {
-        ...(hasOldContent(acc, status) ? { ...acc[status].content } : {}),
-        ...getContent(value.type, contentType, value.description, exampleList),
-      },
+      ...(value.type ? {
+        content: {
+          ...(hasOldContent(acc, status) ? { ...acc[status].content } : {}),
+          ...getContent(value.type, contentType, value.description, exampleList),
+        },
+      } : {}),
     },
   };
 }, {});


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Bugfix
 - [X] Feature
 - [X] Test
 
### Description:

This PR allows the option to provide an empty response in the OpenAPI Docs. This is possible using the OpenAPI `yml`.

In order to do this, we have to use this comment.

```js
/**
 * GET /api/v1
 * @summary This is the summary of the endpoint
 * @return 200 - success response - application/json
 * @return 400 - Bad request response
 */
```

This closes #165 

