### PR TITLE
fix: add support to delete requests with body

### DIFF
--- a/test/transforms/paths/requestBody.test.js
+++ b/test/transforms/paths/requestBody.test.js
@@ -145,6 +145,47 @@ describe('request body tests', () => {
     expect(result).toEqual(expected);
   });
 
+  it('should parse jsdoc request body for delete request', () => {
+    const jsdocInput = [`
+      /**
+       * DELETE /message
+       * @summary Delete messages listed under the specified tags
+       * @param {array<string>} request.body.required - Tags of the messages to delete
+       */
+    `];
+    const expected = {
+      paths: {
+        '/message': {
+          delete: {
+            deprecated: false,
+            summary: 'Delete messages listed under the specified tags',
+            responses: {},
+            tags: [],
+            security: [],
+            parameters: [],
+            requestBody: {
+              description: 'Tags of the messages to delete',
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsdocInput);
+    const result = setPaths({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
+
   it('should parse jsdoc path multiple bodys', () => {
     const jsodInput = [`
       /**

--- a/transforms/utils/httpMethods.js
+++ b/transforms/utils/httpMethods.js
@@ -1,6 +1,6 @@
 const validRequestBodyMethods = {
   get: false,
-  delete: false,
+  delete: true,
   head: false,
   post: true,
   put: true,


### PR DESCRIPTION
### What kind of change does this PR introduce?
 - Bugfix
 - ~Feature~
 - Test
 - ~Docs~
 - ~Refactor~
 - ~Build-related changes~

### Description:

As mentioned in [this link](https://stackoverflow.com/a/10015724/12911174) or in the [official docs for the DELETE method in HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE), this request type should be able to receive a body. 

This PR modifies the `validRequestBodyMethods` configuration object so that `DELETE` methods are now considered eligible to have a request body, so the value `@param {x} request.body` in the endpoint comments will no longer be ignored when generating the Swagger docs.

Should fix #176.