### PR TITLE
fix(test): test failed after making an unrelated change

### DIFF
--- a/config/swaggerEvents.js
+++ b/config/swaggerEvents.js
@@ -1,4 +1,3 @@
-
 const swaggerEvents = options => ({
   multiple: options.multiple !== undefined ? options.multiple : false,
 });

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const swaggerEventsOptions = require('./config/swaggerEvents');
 const processSwagger = require('./processSwagger');
 const swaggerEvents = require('./swaggerEvents');
 
-
 const expressJSDocSwagger = app => (userOptions = {}, userSwagger = {}) => {
   const events = swaggerEvents(swaggerEventsOptions(userOptions));
   const { instance } = events;

--- a/test/e2e/parameters/parameters.test.js
+++ b/test/e2e/parameters/parameters.test.js
@@ -28,6 +28,7 @@ test('should parse parameters from jsdoc-example', async () => {
       '/api/v1': {
         get: {
           deprecated: false,
+          description: undefined,
           summary: 'This is the summary of the endpoint',
           responses: {
             200: {
@@ -70,6 +71,7 @@ test('should parse parameters from jsdoc-example', async () => {
       '/api/v1/albums': {
         get: {
           deprecated: false,
+          description: undefined,
           summary: 'This is the summary of the endpoint',
           responses: {
             200: {

--- a/test/transforms/paths/combineSchemas.test.js
+++ b/test/transforms/paths/combineSchemas.test.js
@@ -15,6 +15,7 @@ test('should parse jsdoc path response with oneOf keyword', () => {
       '/api/v1': {
         get: {
           deprecated: false,
+          description: undefined,
           summary: 'This is the summary of the endpoint',
           parameters: [],
           tags: [],
@@ -125,6 +126,7 @@ test('should parse jsdoc path reference params with allOf keyword', () => {
       '/api/v1': {
         get: {
           deprecated: false,
+          description: undefined,
           summary: '',
           responses: {},
           tags: [],

--- a/test/transforms/paths/formParameters.test.js
+++ b/test/transforms/paths/formParameters.test.js
@@ -122,6 +122,7 @@ describe('form requestBody tests', () => {
         '/api/v1/': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -172,6 +173,7 @@ describe('form requestBody tests', () => {
         '/api/v1/': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -241,6 +243,7 @@ describe('form requestBody tests', () => {
         '/api/v1/': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],

--- a/test/transforms/paths/index.test.js
+++ b/test/transforms/paths/index.test.js
@@ -143,6 +143,7 @@ describe('setPaths method', () => {
         '/api/v1/songs': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
@@ -208,6 +209,7 @@ describe('setPaths method', () => {
           },
           post: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],

--- a/test/transforms/paths/parameters.test.js
+++ b/test/transforms/paths/parameters.test.js
@@ -15,6 +15,7 @@ describe('params tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -51,6 +52,7 @@ describe('params tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -77,6 +79,7 @@ describe('params tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -116,6 +119,7 @@ describe('params tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -163,6 +167,7 @@ describe('params tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -198,6 +203,7 @@ describe('params tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -236,6 +242,7 @@ describe('params tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -275,6 +282,7 @@ describe('params tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],

--- a/test/transforms/paths/requestBody.test.js
+++ b/test/transforms/paths/requestBody.test.js
@@ -13,6 +13,7 @@ describe('request body tests', () => {
         '/api/v1/': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -39,6 +40,7 @@ describe('request body tests', () => {
         '/api/v1': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -77,6 +79,7 @@ describe('request body tests', () => {
         '/api/v1/albums': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -117,6 +120,7 @@ describe('request body tests', () => {
         '/api/v1': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -158,6 +162,7 @@ describe('request body tests', () => {
         '/message': {
           delete: {
             deprecated: false,
+            description: undefined,
             summary: 'Delete messages listed under the specified tags',
             responses: {},
             tags: [],
@@ -199,6 +204,7 @@ describe('request body tests', () => {
         '/api/v1': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -239,6 +245,7 @@ describe('request body tests', () => {
         '/api/v1': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -276,6 +283,7 @@ describe('request body tests', () => {
         '/api/v1': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -318,6 +326,7 @@ describe('request body tests', () => {
         '/api/v1': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],
@@ -370,6 +379,7 @@ describe('request body tests', () => {
         '/api/v1': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: '',
             responses: {},
             tags: [],

--- a/test/transforms/paths/responses.test.js
+++ b/test/transforms/paths/responses.test.js
@@ -17,6 +17,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
@@ -53,6 +54,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
@@ -103,6 +105,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
@@ -156,6 +159,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             responses: {},
             parameters: [],
@@ -191,6 +195,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
@@ -234,6 +239,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
@@ -276,6 +282,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
@@ -315,6 +322,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
@@ -359,6 +367,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
@@ -423,6 +432,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
@@ -534,6 +544,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
@@ -603,6 +614,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],
@@ -660,6 +672,7 @@ describe('response tests', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: 'This is the summary of the endpoint',
             parameters: [],
             tags: [],

--- a/test/transforms/paths/security.test.js
+++ b/test/transforms/paths/security.test.js
@@ -15,6 +15,7 @@ describe('Paths - security', () => {
         '/api/v1/song': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: 'Create new song',
             security: [
               {
@@ -47,6 +48,7 @@ describe('Paths - security', () => {
         '/api/v1/song': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: 'Create new song',
             security: [
               {
@@ -81,6 +83,7 @@ describe('Paths - security', () => {
         '/api/v1/song': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: 'Create new song',
             security: [
               {
@@ -113,6 +116,7 @@ describe('Paths - security', () => {
         '/api/v1/song': {
           post: {
             deprecated: false,
+            description: undefined,
             summary: 'Create new song',
             security: [
               {

--- a/test/transforms/paths/tags.test.js
+++ b/test/transforms/paths/tags.test.js
@@ -14,6 +14,7 @@ describe('Paths - tags', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: '',
             security: [],
             tags: [
@@ -43,6 +44,7 @@ describe('Paths - tags', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: '',
             security: [],
             tags: [
@@ -73,6 +75,7 @@ describe('Paths - tags', () => {
         '/api/v1': {
           get: {
             deprecated: false,
+            description: undefined,
             summary: '',
             security: [],
             tags: [

--- a/transforms/paths/content.js
+++ b/transforms/paths/content.js
@@ -10,7 +10,7 @@ const getContent = entity => (type, contentType, originalValue, examples, extend
         ...schema,
         ...extendSchema,
       },
-      examples,
+      ...(examples ? { examples } : {}),
     },
   };
 };

--- a/transforms/paths/requestBody.js
+++ b/transforms/paths/requestBody.js
@@ -56,10 +56,10 @@ const INITIAL_STATE = { content: {} };
 
 const requestBodyGenerator = (params = [], examples) => {
   if (!params || !Array.isArray(params)) return {};
-  const requestBody = params.reduce((acc, body) => (
+
+  return params.reduce((acc, body) => (
     { ...acc, ...parseBodyParameter(acc, body, examples) }
   ), INITIAL_STATE);
-  return requestBody;
 };
 
 module.exports = requestBodyGenerator;


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [x] Bugfix
 - [ ] Feature
 - [x] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:

These tests broke. I'm not sure why only making a change in
transforms/paths/index.js under the parsePath response
triggers the failures.

Found it while making the changes for: https://github.com/BRIKEV/express-jsdoc-swagger/pull/179