### PR TITLE
Fix/files pattern bug

### DIFF
--- a/consumers/utils/getComments.js
+++ b/consumers/utils/getComments.js
@@ -1,4 +1,4 @@
-const COMMENTS_PATTERN = /((\/\*+[\s\S]*?\*\/)|(\/\*+.*\*\/)|^\/\/.*?[\r\n])[\r\n]*/gm;
+const COMMENTS_PATTERN = /((\/\*\*+[\s\S]*?\*\/)|(\/\*+.*\*\/)|^\/\/.*?[\r\n])[\r\n]*/gm;
 const BREAK_LINE = /\n/g;
 
 const getComments = text => {

--- a/test/consumers/getOnlyComments/index.test.js
+++ b/test/consumers/getOnlyComments/index.test.js
@@ -74,6 +74,26 @@ describe('get only comments consumer method', () => {
     expect(result).toEqual(expected);
   });
 
+  it('should return only the JSdoc comment when we add a regex in the file pattern', () => {
+    const input = [`
+    const pattern = './*.js';
+    /**
+     * @param  {[type]}
+     * @param  {[type]}
+     * @return {[type]}
+     */
+
+    `];
+    const expected = [`/**
+     * @param  {[type]}
+     * @param  {[type]}
+     * @return {[type]}
+     */`];
+    const result = getOnlyComments(input);
+    expect(result).toHaveLength(1);
+    expect(result).toEqual(expected);
+  });
+
   it('should return multiline and JSdoc comment', () => {
     const input = [`
     /* this is a comment */


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Bugfix

### Description:
This PR fixes an error in our get comments regex when we have to read files with patterns like these ones `./*` `./*.*`.

This closes #184 
