### PR TITLE
Add support for non-object typedefs

### DIFF
--- a/test/transforms/components/index.test.js
+++ b/test/transforms/components/index.test.js
@@ -799,4 +799,52 @@ describe('parseComponents method', () => {
     const result = parseComponents({}, parsedJSDocs, { notRequiredAsNullable: true });
     expect(result).toEqual(expected);
   });
+
+  it('Should parse jsdoc component spec with string type', () => {
+    const jsodInput = [`
+      /**
+       * A song
+       * @typedef {string} Song
+       */
+    `];
+    const expected = {
+      components: {
+        schemas: {
+          Song: {
+            type: 'string',
+            description: 'A song',
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = parseComponents({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
+
+  it('Should parse jsdoc component spec with string type and a format', () => {
+    const jsodInput = [`
+      /**
+       * A song - enum:value1,value2
+       * @typedef {string} Song
+       */
+    `];
+    const expected = {
+      components: {
+        schemas: {
+          Song: {
+            type: 'string',
+            description: 'A song',
+            enum: [
+              'value1',
+              'value2',
+            ],
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = parseComponents({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
 });

--- a/transforms/components/index.js
+++ b/transforms/components/index.js
@@ -68,19 +68,27 @@ const parseSchema = (schema, options = {}) => {
   const typedef = getTagInfo(schema.tags, 'typedef');
   const propertyValues = getTagsInfo(schema.tags, 'property');
   const requiredProperties = getRequiredProperties(propertyValues);
+  const [descriptionValue, enumValues, jsonOptions] = formatDescription(schema.description);
+  const [description, format] = mapDescription(descriptionValue);
   if (!typedef || !typedef.name) return {};
   const {
     elements,
   } = typedef.type;
+  const type = typedef.type.name || 'object';
   return {
     [typedef.name]: {
       ...combineSchema(elements),
-      description: schema.description,
+      description,
       ...(requiredProperties.length ? {
         required: formatRequiredProperties(requiredProperties),
       } : {}),
-      type: 'object',
-      properties: formatProperties(propertyValues, options),
+      type,
+      ...(type === 'object' ? {
+        properties: formatProperties(propertyValues, options),
+      } : {}),
+      ...(format ? { format } : {}),
+      ...addEnumValues(enumValues),
+      ...(jsonOptions || {}),
     },
   };
 };


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:
 This adds support for non-object typedefs such as string - previously it would emit an "object" type for non-object typedefs