### PR TITLE
feat: support for dictionaries

### DIFF
--- a/test/transforms/components/index.test.js
+++ b/test/transforms/components/index.test.js
@@ -847,4 +847,48 @@ describe('parseComponents method', () => {
     const result = parseComponents({}, parsedJSDocs);
     expect(result).toEqual(expected);
   });
+
+  it('Should parse jsdoc component spec dictionary', () => {
+    const jsodInput = [`
+       /**
+        * Profile
+        * @typedef {object} Profile
+        *
+        * @property {string} email
+        */
+      `,
+    `
+       /**
+        * Profiles dict
+        * @typedef {Object.<string, Profile>} Profiles
+        */
+    `];
+    const expected = {
+      components: {
+        schemas: {
+          Profile: {
+            type: 'object',
+            description: 'Profile',
+            properties: {
+              email: {
+                type: 'string',
+                description: '',
+              },
+            },
+          },
+          Profiles: {
+            type: 'object',
+            description: 'Profiles dict',
+            properties: {},
+            additionalProperties: {
+              $ref: '#/components/schemas/Profile',
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = parseComponents({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
 });

--- a/test/transforms/components/index.test.js
+++ b/test/transforms/components/index.test.js
@@ -860,7 +860,7 @@ describe('parseComponents method', () => {
     `
        /**
         * Profiles dict
-        * @typedef {Object.<string, Profile>} Profiles
+        * @typedef {Dictionary<Profile>} Profiles
         */
     `];
     const expected = {

--- a/transforms/components/index.js
+++ b/transforms/components/index.js
@@ -64,6 +64,17 @@ const getRequiredProperties = properties => (
 
 const formatRequiredProperties = requiredProperties => requiredProperties.map(getPropertyName);
 
+const addDictionaryAdditionalProperties = typedef => {
+  if (typedef.type?.applications?.length === 2 && typedef.type.applications[0].name === 'string') {
+    return {
+      additionalProperties: {
+        $ref: `#/components/schemas/${typedef.type.applications[1].name}`,
+      },
+    };
+  }
+  return {};
+};
+
 const parseSchema = (schema, options = {}) => {
   const typedef = getTagInfo(schema.tags, 'typedef');
   const propertyValues = getTagsInfo(schema.tags, 'property');
@@ -88,6 +99,7 @@ const parseSchema = (schema, options = {}) => {
       } : {}),
       ...(format ? { format } : {}),
       ...addEnumValues(enumValues),
+      ...addDictionaryAdditionalProperties(typedef),
       ...(jsonOptions || {}),
     },
   };

--- a/transforms/components/index.js
+++ b/transforms/components/index.js
@@ -65,7 +65,7 @@ const getRequiredProperties = properties => (
 const formatRequiredProperties = requiredProperties => requiredProperties.map(getPropertyName);
 
 const addDictionaryAdditionalProperties = typedef => {
-  if (typedef.type?.applications?.length === 2 && typedef.type.applications[0].name === 'string') {
+  if (typedef.type.applications && typedef.type.applications.length === 2 && typedef.type.applications[0].name === 'string') {
     return {
       additionalProperties: {
         $ref: `#/components/schemas/${typedef.type.applications[1].name}`,

--- a/transforms/components/index.js
+++ b/transforms/components/index.js
@@ -65,14 +65,15 @@ const getRequiredProperties = properties => (
 const formatRequiredProperties = requiredProperties => requiredProperties.map(getPropertyName);
 
 const addDictionaryAdditionalProperties = typedef => {
-  if (typedef.type.applications && typedef.type.applications.length === 2 && typedef.type.applications[0].name === 'string') {
-    return {
-      additionalProperties: {
-        $ref: `#/components/schemas/${typedef.type.applications[1].name}`,
-      },
-    };
+  if (!typedef.type.expression || typedef.type.expression.name !== 'Dictionary') {
+    return {};
   }
-  return {};
+
+  return {
+    additionalProperties: {
+      $ref: `#/components/schemas/${typedef.type.applications[0].name}`,
+    },
+  };
 };
 
 const parseSchema = (schema, options = {}) => {


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [x ] Feature
 - [ ] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:

This PR adds support for dictionaries with objects as values as described in the OpenAPI spec under "Value type" (second example here: https://swagger.io/docs/specification/data-models/dictionaries/
As my understanding of the codebase is limited I don't think the implementation is optimal but hopefully someone with more familiarity of the codebase can refactor it to a satisfactory level?