### PR TITLE
fix: schema type casing

### DIFF
--- a/test/transforms/components/index.test.js
+++ b/test/transforms/components/index.test.js
@@ -647,13 +647,29 @@ describe('parseComponents method', () => {
   });
 
   it('Should parse an album schema with an array of Songs schemas.', () => {
-    const jsodInput = [`
-      /**
-       * Album
-       * @typedef {object} Album
-       * @property {array<Song>} Songs
-       */
-    `];
+    const jsodInput = [
+      [`
+        /**
+         * Album
+         * @typedef {object} Album
+         * @property {array<Song>} Songs
+         */
+      `],
+      [`
+        /**
+         * Album
+         * @typedef {object} Album
+         * @property {Array<Song>} Songs
+         */
+      `],
+      [`
+        /**
+         * Album
+         * @typedef {object} Album
+         * @property {Song[]} Songs
+         */
+      `],
+    ];
     const expected = {
       components: {
         schemas: {
@@ -673,9 +689,11 @@ describe('parseComponents method', () => {
         },
       },
     };
-    const parsedJSDocs = jsdocInfo()(jsodInput);
-    const result = parseComponents({}, parsedJSDocs);
-    expect(result).toEqual(expected);
+    jsodInput.forEach(jsod => {
+      const parsedJSDocs = jsdocInfo()(jsod);
+      const result = parseComponents({}, parsedJSDocs);
+      expect(result).toEqual(expected);
+    });
   });
 
   it('Should parse a SingleAlbum schema with allOf reference of Song.', () => {

--- a/test/transforms/paths/parameters.test.js
+++ b/test/transforms/paths/parameters.test.js
@@ -68,26 +68,12 @@ describe('params tests', () => {
   });
 
   it('should parse jsdoc path params with array type', () => {
-    const jsodInput = [
-      [`
-        /**
-         * GET /api/v1
-         * @param {array<string>} name.query.required.deprecated - name param description
-         */
-      `],
-      [`
-        /**
-         * GET /api/v1
-         * @param {Array<string>} name.query.required.deprecated - name param description
-         */
-      `],
-      [`
-        /**
-         * GET /api/v1
-         * @param {string[]} name.query.required.deprecated - name param description
-         */
-      `],
-    ];
+    const jsodInput = [`
+      /**
+       * GET /api/v1
+       * @param {array<string>} name.query.required.deprecated - name param description
+       */
+    `];
     const expected = {
       paths: {
         '/api/v1': {
@@ -115,11 +101,9 @@ describe('params tests', () => {
         },
       },
     };
-    jsodInput.forEach(jsod => {
-      const parsedJSDocs = jsdocInfo()(jsod);
-      const result = setPaths({}, parsedJSDocs);
-      expect(result).toEqual(expected);
-    });
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = setPaths({}, parsedJSDocs);
+    expect(result).toEqual(expected);
   });
 
   it('should parse jsdoc path multiple params', () => {

--- a/test/transforms/paths/parameters.test.js
+++ b/test/transforms/paths/parameters.test.js
@@ -68,12 +68,26 @@ describe('params tests', () => {
   });
 
   it('should parse jsdoc path params with array type', () => {
-    const jsodInput = [`
-      /**
-       * GET /api/v1
-       * @param {array<string>} name.query.required.deprecated - name param description
-       */
-    `];
+    const jsodInput = [
+      [`
+        /**
+         * GET /api/v1
+         * @param {array<string>} name.query.required.deprecated - name param description
+         */
+      `],
+      [`
+        /**
+         * GET /api/v1
+         * @param {Array<string>} name.query.required.deprecated - name param description
+         */
+      `],
+      [`
+        /**
+         * GET /api/v1
+         * @param {string[]} name.query.required.deprecated - name param description
+         */
+      `],
+    ];
     const expected = {
       paths: {
         '/api/v1': {
@@ -101,9 +115,11 @@ describe('params tests', () => {
         },
       },
     };
-    const parsedJSDocs = jsdocInfo()(jsodInput);
-    const result = setPaths({}, parsedJSDocs);
-    expect(result).toEqual(expected);
+    jsodInput.forEach(jsod => {
+      const parsedJSDocs = jsdocInfo()(jsod);
+      const result = setPaths({}, parsedJSDocs);
+      expect(result).toEqual(expected);
+    });
   });
 
   it('should parse jsdoc path multiple params', () => {
@@ -192,12 +208,26 @@ describe('params tests', () => {
   });
 
   it('should parse jsdoc path params with array of references', () => {
-    const jsodInput = [`
-      /**
-       * GET /api/v1
-       * @param {array<Song>} name.query.required.deprecated - name param description
-       */
-    `];
+    const jsodInput = [
+      [`
+        /**
+         * GET /api/v1
+         * @param {array<Song>} name.query.required.deprecated - name param description
+         */
+      `],
+      [`
+        /**
+         * GET /api/v1
+         * @param {Array<Song>} name.query.required.deprecated - name param description
+         */
+      `],
+      [`
+        /**
+         * GET /api/v1
+         * @param {Song[]} name.query.required.deprecated - name param description
+         */
+      `],
+    ];
     const expected = {
       paths: {
         '/api/v1': {
@@ -225,9 +255,11 @@ describe('params tests', () => {
         },
       },
     };
-    const parsedJSDocs = jsdocInfo()(jsodInput);
-    const result = setPaths({}, parsedJSDocs);
-    expect(result).toEqual(expected);
+    jsodInput.forEach(jsod => {
+      const parsedJSDocs = jsdocInfo()(jsod);
+      const result = setPaths({}, parsedJSDocs);
+      expect(result).toEqual(expected);
+    });
   });
 
   it('should parse jsdoc path params with enum values', () => {

--- a/transforms/components/index.js
+++ b/transforms/components/index.js
@@ -15,7 +15,7 @@ const getPropertyName = ({ name: propertyName }) => {
 const addTypeApplication = (applications, expression) => {
   if (!applications && !expression) return {};
   return {
-    type: expression.name,
+    type: expression.name.toLowerCase(),
     items: {
       type: applications[0].name,
     },

--- a/transforms/paths/schema.js
+++ b/transforms/paths/schema.js
@@ -23,7 +23,7 @@ const getSchema = (entity, message) => (type, enumValues = [], jsonOptions = {})
     const parseItems = formatRefSchema(type.applications);
     schema = {
       ...schema,
-      type: type.expression.name,
+      type: type.expression.name.toLowerCase(),
       items: parseItems.items ? parseItems.items : parseItems,
     };
   }


### PR DESCRIPTION
Update logic for type application casing to ensure lowercase.

### What kind of change does this PR introduce? (check at least one)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:

When types such as `Array<Song>` or `Song[]` are used, the `type` for the property resolves to `'Array'` rather than the officially support OpenAPI [data type](https://swagger.io/docs/specification/data-models/data-types/) of `'array'`. When the type is `'Array'`, the OpenAPI document does not correctly recognize the property as a valid array. The officially supported types are lowercase anyway:

- [string](https://swagger.io/docs/specification/data-models/data-types/#string) (this includes dates and [files](https://swagger.io/docs/specification/data-models/data-types/#file))
- [number](https://swagger.io/docs/specification/data-models/data-types/#numbers)
- [integer](https://swagger.io/docs/specification/data-models/data-types/#numbers)
- [boolean](https://swagger.io/docs/specification/data-models/data-types/#boolean)
- [array](https://swagger.io/docs/specification/data-models/data-types/#array)
- [object](https://swagger.io/docs/specification/data-models/data-types/#object)