### PR TITLE
feat: add support for dictionary primitives

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Jest Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229
+    }
+  ]
+}

--- a/test/transforms/components/index.test.js
+++ b/test/transforms/components/index.test.js
@@ -909,4 +909,30 @@ describe('parseComponents method', () => {
     const result = parseComponents({}, parsedJSDocs);
     expect(result).toEqual(expected);
   });
+
+  it('Should parse jsdoc component spec record type', () => {
+    const jsodInput = [`
+      /**
+      * Records dict
+      * @typedef {Dictionary<string>} Records map
+      */
+    `];
+    const expected = {
+      components: {
+        schemas: {
+          Records: {
+            type: 'object',
+            description: 'Records dict',
+            properties: {},
+            additionalProperties: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    };
+    const parsedJSDocs = jsdocInfo()(jsodInput);
+    const result = parseComponents({}, parsedJSDocs);
+    expect(result).toEqual(expected);
+  });
 });


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:

Add support for using primitive values with `Dictionary` special type. For example to represent object with any number of string keys and string values:

```
{
  "en": "English",
  "fr": "French"
}
```

Official documentation on dictionaries in OpenAPI:
https://swagger.io/docs/specification/data-models/dictionaries/

While `object` is technically a primitive value based on `TYPES` in `transforms/utils/validateTypes.js`, users of this library will want to use `typedef` to represent objects.

For what it's worth, normally in JSDoc [dictionary/record](https://jsdoc.app/tags-type.html) type objects are represented as:

```
Object.<string,string>
```