### PR TITLE
Type: Improved type for SecurityObject to include oauth2 & apiKey

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "ecmaVersion": 11
   },
   "rules": {
+    "linebreak-style": ["error", "windows"],
     "arrow-parens": [
       "error",
       "as-needed",

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,35 +30,39 @@ interface InfoObject {
 }
 
 type SecurityObject = {
-  type: "http" | "https" | "ws" | "wss";
-  description?: string;
+  scheme: 'http' | 'https' | 'ws' | 'wss'
+  description?: string
 } & (
-    {
-      scheme: 'basic';
-    } | 
-    { 
-      scheme: 'apiKey';
-      name: string; 
-      in: "query" | "header"; 
-    } | (
-    {
-      scheme: "oauth2";
-      scopes: {[key:string]: string}
-    } & ({
-      flow: "implicit";
-      authorizationUrl: string;
-    } | {
-      flow: "password";
-      tokenUrl: string;
-    } | {
-      flow: "application";
-      tokenUrl: string;
-    } | {
-      flow: "accessCode";
-      authorizationUrl: string;
-      tokenUrl: string;
-    })
-  )
+  | {
+      type: 'basic'
+    }
+  | {
+      type: 'apiKey'
+      name: string
+      in: 'query' | 'header'
+    }
+  | ({
+      type: 'oauth2'
+      scopes: { [key: string]: string }
+    } & (
+      | {
+          flow: 'implicit'
+          authorizationUrl: string
+        }
+      | {
+          flow: 'password'
+          tokenUrl: string
+        }
+      | {
+          flow: 'application'
+          tokenUrl: string
+        }
+      | {
+          flow: 'accessCode'
+          authorizationUrl: string
+          tokenUrl: string
+        }
+    ))
 )
 
 interface Security {

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,10 +29,37 @@ interface InfoObject {
   license?: LicenseObject;
 }
 
-interface SecurityObject {
-  type: string;
-  scheme: string;
-}
+type SecurityObject = {
+  type: "http" | "https" | "ws" | "wss";
+  description?: string;
+} & (
+    {
+      scheme: 'basic';
+    } | 
+    { 
+      scheme: 'apiKey';
+      name: string; 
+      in: "query" | "header"; 
+    } | (
+    {
+      scheme: "oauth2";
+      scopes: {[key:string]: string}
+    } & ({
+      flow: "implicit";
+      authorizationUrl: string;
+    } | {
+      flow: "password";
+      tokenUrl: string;
+    } | {
+      flow: "application";
+      tokenUrl: string;
+    } | {
+      flow: "accessCode";
+      authorizationUrl: string;
+      tokenUrl: string;
+    })
+  )
+)
 
 interface Security {
   [key: string]: SecurityObject;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2287,16 +2287,6 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
-    "node_modules/browserslist/node_modules/caniuse-lite": {
-      "version": "1.0.30001230",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
-      "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
-    },
     "node_modules/browserslist/node_modules/colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
@@ -2405,6 +2395,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001538",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz",
+      "integrity": "sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -11405,12 +11415,6 @@
         "node-releases": "^1.1.71"
       },
       "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001230",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
-          "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
-          "dev": true
-        },
         "colorette": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
@@ -11500,6 +11504,12 @@
         "map-obj": "^4.0.0",
         "quick-lru": "^4.0.1"
       }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001538",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz",
+      "integrity": "sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==",
+      "dev": true
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/test/consumers/globFilesMatches/index.test.js
+++ b/test/consumers/globFilesMatches/index.test.js
@@ -34,7 +34,7 @@ describe('glob Files matches method', () => {
     const filePath = './**/**.txt';
     globFilesMatches(baseDir, filePath)
       .catch(error => {
-        expect(error.message).toMatch(/The "path" argument must be of type string. Received type number/);
+        expect(error.message).toMatch(/argument must be of type string. Received type number/);
         done();
       });
   });

--- a/test/transforms/security/index.test.js
+++ b/test/transforms/security/index.test.js
@@ -62,6 +62,38 @@ describe('Transform security schemas', () => {
     expect(result).toEqual(expected);
   });
 
+  it('Should return a security array and securitySchemes within components field', () => {
+    const input = {
+      security: {
+        ApiKeyAuth: {
+          type: 'http',
+          scheme: "apiKey",
+          name: "api_key",
+          in: "header"
+        },
+      },
+    };
+    const expected = {
+      security: [
+        {
+          ApiKeyAuth: [],
+        },
+      ],
+      components: {
+        securitySchemes: {
+          ApiKeyAuth: {
+            type: 'http',
+            scheme: "apiKey",
+            name: "api_key",
+            in: "header"
+          },
+        },
+      },
+    };
+    const result = parseSecuritySchemas(input);
+    expect(result).toEqual(expected);
+  });
+
   it('Should return a security array and securitySchemes, both with each security type', () => {
     const input = {
       security: {


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [x] Bugfix
 - [x] Feature
 - [x] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:
Type: Improved type for SecurityObject to include oauth2 & apiKey.

There was also a bug with a tests, where the error contained "paths[0]" instead of "path". So, omitted the first part of the message from the regex. 

Also enforced windows line endings. These were already present, but sometimes eslint tries to change to unix depending on the system.